### PR TITLE
Major rewrite of TimeParser

### DIFF
--- a/src/ValueParsers/IsoTimestampParser.php
+++ b/src/ValueParsers/IsoTimestampParser.php
@@ -93,6 +93,9 @@ class IsoTimestampParser extends StringValueParser {
 
 		if ( !preg_match( $pattern, $value, $matches ) ) {
 			throw new ParseException( 'Malformed time', $value, self::FORMAT_NAME );
+		} elseif ( $matches[2] < 60 && $matches[5] === '' ) {
+			throw new ParseException( 'Not enough information to decide if the format is YY-MM-DD',
+				$value, self::FORMAT_NAME );
 		} elseif ( $matches[3] > 12 ) {
 			throw new ParseException( 'Month out of range', $value, self::FORMAT_NAME );
 		} elseif ( $matches[4] > 31 ) {
@@ -101,6 +104,8 @@ class IsoTimestampParser extends StringValueParser {
 			throw new ParseException( 'Hour out of range', $value, self::FORMAT_NAME );
 		} elseif ( $matches[6] > 59 ) {
 			throw new ParseException( 'Minute out of range', $value, self::FORMAT_NAME );
+		} elseif ( $matches[7] > 62 ) {
+			throw new ParseException( 'Second out of range', $value, self::FORMAT_NAME );
 		}
 
 		return array_slice( $matches, 1 );

--- a/src/ValueParsers/IsoTimestampParser.php
+++ b/src/ValueParsers/IsoTimestampParser.php
@@ -84,7 +84,7 @@ class IsoTimestampParser extends StringValueParser {
 	 */
 	private function splitTimeString( $value ) {
 		$pattern = '@^\s*'                                                //leading spaces
-			. '([-+]?)\s*'                                                //sign
+			. "([-+\xE2\x88\x92]?)\\s*"                                   //sign
 			. '(\d{1,16})-(\d{2})-(\d{2})'                                //year, month and day
 			. '(?:T(\d{2}):(\d{2})(?::(\d{2}))?)?'                        //hour, minute and second
 			. 'Z?'                                                        //time zone
@@ -108,7 +108,11 @@ class IsoTimestampParser extends StringValueParser {
 			throw new ParseException( 'Second out of range', $value, self::FORMAT_NAME );
 		}
 
-		return array_slice( $matches, 1 );
+
+		$matches = array_slice( $matches, 1 );
+		$matches[0] = str_replace( "\xE2\x88\x92", '-', $matches[0] );
+
+		return $matches;
 	}
 
 	/**

--- a/src/ValueParsers/IsoTimestampParser.php
+++ b/src/ValueParsers/IsoTimestampParser.php
@@ -93,6 +93,14 @@ class IsoTimestampParser extends StringValueParser {
 
 		if ( !preg_match( $pattern, $value, $matches ) ) {
 			throw new ParseException( 'Malformed time', $value, self::FORMAT_NAME );
+		} elseif ( $matches[3] > 12 ) {
+			throw new ParseException( 'Month out of range', $value, self::FORMAT_NAME );
+		} elseif ( $matches[4] > 31 ) {
+			throw new ParseException( 'Day out of range', $value, self::FORMAT_NAME );
+		} elseif ( $matches[5] > 23 ) {
+			throw new ParseException( 'Hour out of range', $value, self::FORMAT_NAME );
+		} elseif ( $matches[6] > 59 ) {
+			throw new ParseException( 'Minute out of range', $value, self::FORMAT_NAME );
 		}
 
 		return array_slice( $matches, 1 );

--- a/src/ValueParsers/IsoTimestampParser.php
+++ b/src/ValueParsers/IsoTimestampParser.php
@@ -7,10 +7,14 @@ use DataValues\TimeValue;
 use InvalidArgumentException;
 
 /**
- * ValueParser that parses YMD ordered timestamp strings resembling ISO 8601, e.g.
- * +2013-01-01T00:00:00Z. While the parser tries to be relaxed, certain aspects of the ISO norm are
- * obligatory: The order must be YMD. All elements but the year must have 2 digits. The seperation
- * characters must be dashes (in the date part), "T" and colons (in the time part).
+ * ValueParser that parses various string representations of time values, in YMD ordered formats
+ * resembling ISO 8601, e.g. +2013-01-01T00:00:00Z. While the parser tries to be relaxed, certain
+ * aspects of the ISO norm are obligatory: The order must be YMD. All elements but the year must
+ * have 2 digits. The seperation characters must be dashes (in the date part), "T" and colons (in
+ * the time part).
+ *
+ * The parser refuses to parse strings that can be parsed differently by other, locale-aware
+ * parsers, e.g. 01-02-03 can be in YMD, DMY or MDY order depending on the language.
  *
  * @since 0.7
  *
@@ -93,8 +97,8 @@ class IsoTimestampParser extends StringValueParser {
 
 		if ( !preg_match( $pattern, $value, $matches ) ) {
 			throw new ParseException( 'Malformed time', $value, self::FORMAT_NAME );
-		} elseif ( $matches[2] < 60 && $matches[5] === '' ) {
-			throw new ParseException( 'Not enough information to decide if the format is YY-MM-DD',
+		} elseif ( strlen( $matches[2] ) < 3 && $matches[2] < 60 && $matches[5] === '' ) {
+			throw new ParseException( 'Not enough information to decide if the format is YMD',
 				$value, self::FORMAT_NAME );
 		} elseif ( $matches[3] > 12 ) {
 			throw new ParseException( 'Month out of range', $value, self::FORMAT_NAME );

--- a/tests/ValueParsers/CalendarModelParserTest.php
+++ b/tests/ValueParsers/CalendarModelParserTest.php
@@ -6,7 +6,7 @@ use ValueFormatters\TimeFormatter;
 use ValueParsers\CalendarModelParser;
 
 /**
- * @covers \ValueParsers\CalendarModelParser
+ * @covers ValueParsers\CalendarModelParser
  *
  * @group DataValue
  * @group DataValueExtensions
@@ -19,7 +19,7 @@ class CalendarModelParserTest extends ValueParserTestBase {
 	 * @deprecated since 0.3, just use getInstance.
 	 */
 	protected function getParserClass() {
-		return 'ValueParsers\CalendarModelParser';
+		throw new \LogicException( 'Should not be called, use getInstance' );
 	}
 
 	/**

--- a/tests/ValueParsers/IsoTimestampParserTest.php
+++ b/tests/ValueParsers/IsoTimestampParserTest.php
@@ -342,6 +342,17 @@ class IsoTimestampParserTest extends ValueParserTestBase {
 				),
 			),
 
+			// Actual minus character from Unicode; roundtrip with TimeDetailsFormatter
+			"\xE2\x88\x922015-01-01T00:00:00" => array(
+				new TimeValue(
+					'-0000000000002015-01-01T00:00:00Z',
+					0, 0, 0,
+					TimeValue::PRECISION_DAY,
+					TimeFormatter::CALENDAR_GREGORIAN
+				),
+				$noPrecOpts,
+			),
+
 			// Optional second
 			'2015-01-01T00:00' => array(
 				new TimeValue(

--- a/tests/ValueParsers/IsoTimestampParserTest.php
+++ b/tests/ValueParsers/IsoTimestampParserTest.php
@@ -59,397 +59,220 @@ class IsoTimestampParserTest extends ValueParserTestBase {
 		$valid = array(
 			// Empty options tests
 			'+0000000000002013-07-16T00:00:00Z' => array(
-				new TimeValue(
-					'+0000000000002013-07-16T00:00:00Z',
-					0, 0, 0,
-					TimeValue::PRECISION_DAY,
-					$gregorian
-				),
+				'+0000000000002013-07-16T00:00:00Z',
+				TimeValue::PRECISION_DAY,
 			),
 			'+0000000000002013-07-00T00:00:00Z' => array(
-				new TimeValue(
-					'+0000000000002013-07-00T00:00:00Z',
-					0, 0, 0,
-					TimeValue::PRECISION_MONTH,
-					$gregorian
-				),
+				'+0000000000002013-07-00T00:00:00Z',
+				TimeValue::PRECISION_MONTH,
 			),
 			'+0000000000002013-00-00T00:00:00Z' => array(
-				new TimeValue(
-					'+0000000000002013-00-00T00:00:00Z',
-					0, 0, 0,
-					TimeValue::PRECISION_YEAR,
-					$gregorian
-				),
+				'+0000000000002013-00-00T00:00:00Z',
+				TimeValue::PRECISION_YEAR,
 			),
 			'+0000000000000000-00-00T00:00:00Z' => array(
-				new TimeValue(
-					'+0000000000000000-00-00T00:00:00Z',
-					0, 0, 0,
-					TimeValue::PRECISION_YEAR,
-					TimeFormatter::CALENDAR_GREGORIAN
-				),
-				$emptyOpts,
+				'+0000000000000000-00-00T00:00:00Z',
+				TimeValue::PRECISION_YEAR,
 			),
 			'+0000000000002000-00-00T00:00:00Z' => array(
-				new TimeValue(
-					'+0000000000002000-00-00T00:00:00Z',
-					0, 0, 0,
-					TimeValue::PRECISION_YEAR,
-					$gregorian
-				),
+				'+0000000000002000-00-00T00:00:00Z',
+				TimeValue::PRECISION_YEAR,
 			),
 			'+0000000000008000-00-00T00:00:00Z' => array(
-				new TimeValue(
-					'+0000000000008000-00-00T00:00:00Z',
-					0, 0, 0,
-					TimeValue::PRECISION_ka,
-					$gregorian
-				),
+				'+0000000000008000-00-00T00:00:00Z',
+				TimeValue::PRECISION_ka,
 			),
 			'+0000000000020000-00-00T00:00:00Z' => array(
-				new TimeValue(
-					'+0000000000020000-00-00T00:00:00Z',
-					0, 0, 0,
-					TimeValue::PRECISION_10ka,
-					$gregorian
-				),
+				'+0000000000020000-00-00T00:00:00Z',
+				TimeValue::PRECISION_10ka,
 			),
 			'+0000000000200000-00-00T00:00:00Z' => array(
-				new TimeValue(
-					'+0000000000200000-00-00T00:00:00Z',
-					0, 0, 0,
-					TimeValue::PRECISION_100ka,
-					$gregorian
-				),
+				'+0000000000200000-00-00T00:00:00Z',
+				TimeValue::PRECISION_100ka,
 			),
 			'+0000000002000000-00-00T00:00:00Z' => array(
-				new TimeValue(
-					'+0000000002000000-00-00T00:00:00Z',
-					0, 0, 0,
-					TimeValue::PRECISION_Ma,
-					$gregorian
-				),
+				'+0000000002000000-00-00T00:00:00Z',
+				TimeValue::PRECISION_Ma,
 			),
 			'+0000000020000000-00-00T00:00:00Z' => array(
-				new TimeValue(
-					'+0000000020000000-00-00T00:00:00Z',
-					0, 0, 0,
-					TimeValue::PRECISION_10Ma,
-					$gregorian
-				),
+				'+0000000020000000-00-00T00:00:00Z',
+				TimeValue::PRECISION_10Ma,
 			),
 			'+0000000200000000-00-00T00:00:00Z' => array(
-				new TimeValue(
-					'+0000000200000000-00-00T00:00:00Z',
-					0, 0, 0,
-					TimeValue::PRECISION_100Ma,
-					$gregorian
-				),
+				'+0000000200000000-00-00T00:00:00Z',
+				TimeValue::PRECISION_100Ma,
 			),
 			'+0000002000000000-00-00T00:00:00Z' => array(
-				new TimeValue(
-					'+0000002000000000-00-00T00:00:00Z',
-					0, 0, 0,
-					TimeValue::PRECISION_Ga,
-					$gregorian
-				),
+				'+0000002000000000-00-00T00:00:00Z',
+				TimeValue::PRECISION_Ga,
 			),
 			'+0000020000000000-00-00T00:00:00Z' => array(
-				new TimeValue(
-					'+0000020000000000-00-00T00:00:00Z',
-					0, 0, 0,
-					TimeValue::PRECISION_Ga,
-					$gregorian
-				),
+				'+0000020000000000-00-00T00:00:00Z',
+				TimeValue::PRECISION_Ga,
 			),
 			'+0000200000000000-00-00T00:00:00Z' => array(
-				new TimeValue(
-					'+0000200000000000-00-00T00:00:00Z',
-					0, 0, 0,
-					TimeValue::PRECISION_Ga,
-					$gregorian
-				),
+				'+0000200000000000-00-00T00:00:00Z',
+				TimeValue::PRECISION_Ga,
 			),
 			'+0002000000000000-00-00T00:00:00Z' => array(
-				new TimeValue(
-					'+0002000000000000-00-00T00:00:00Z',
-					0, 0, 0,
-					TimeValue::PRECISION_Ga,
-					$gregorian
-				),
+				'+0002000000000000-00-00T00:00:00Z',
+				TimeValue::PRECISION_Ga,
 			),
 			'+0020000000000000-00-00T00:00:00Z' => array(
-				new TimeValue(
-					'+0020000000000000-00-00T00:00:00Z',
-					0, 0, 0,
-					TimeValue::PRECISION_Ga,
-					$gregorian
-				),
+				'+0020000000000000-00-00T00:00:00Z',
+				TimeValue::PRECISION_Ga,
 			),
 			'+0200000000000000-00-00T00:00:00Z' => array(
-				new TimeValue(
-					'+0200000000000000-00-00T00:00:00Z',
-					0, 0, 0,
-					TimeValue::PRECISION_Ga,
-					$gregorian
-				),
+				'+0200000000000000-00-00T00:00:00Z',
+				TimeValue::PRECISION_Ga,
 			),
 			'+2000000000000000-00-00T00:00:00Z' => array(
-				new TimeValue(
-					'+2000000000000000-00-00T00:00:00Z',
-					0, 0, 0,
-					TimeValue::PRECISION_Ga,
-					$gregorian
-				),
+				'+2000000000000000-00-00T00:00:00Z',
+				TimeValue::PRECISION_Ga,
 			),
 			'+0000000000002013-07-16T00:00:00Z (Gregorian)' => array(
-				new TimeValue(
-					'+0000000000002013-07-16T00:00:00Z',
-					0, 0, 0,
-					TimeValue::PRECISION_DAY,
-					$gregorian
-				),
+				'+0000000000002013-07-16T00:00:00Z',
+				TimeValue::PRECISION_DAY,
 			),
 			'+0000000000000000-01-01T00:00:00Z (Gregorian)' => array(
-				new TimeValue(
-					'+0000000000000000-01-01T00:00:00Z',
-					0, 0, 0,
-					TimeValue::PRECISION_DAY,
-					$gregorian
-				),
+				'+0000000000000000-01-01T00:00:00Z',
+				TimeValue::PRECISION_DAY,
+
 			),
 			'+0000000000000001-01-14T00:00:00Z (Julian)' => array(
-				new TimeValue(
-					'+0000000000000001-01-14T00:00:00Z',
-					0, 0, 0,
-					TimeValue::PRECISION_DAY,
-					$julian
-				),
+				'+0000000000000001-01-14T00:00:00Z',
+				TimeValue::PRECISION_DAY,
+				$julian,
 			),
 			'+0000000000010000-01-01T00:00:00Z (Gregorian)' => array(
-				new TimeValue(
-					'+0000000000010000-01-01T00:00:00Z',
-					0, 0, 0,
-					TimeValue::PRECISION_DAY,
-					$gregorian
-				),
+				'+0000000000010000-01-01T00:00:00Z',
+				TimeValue::PRECISION_DAY,
 			),
 			'-0000000000000001-01-01T00:00:00Z (Gregorian)' => array(
-				new TimeValue(
-					'-0000000000000001-01-01T00:00:00Z',
-					0, 0, 0,
-					TimeValue::PRECISION_DAY,
-					$gregorian
-				),
+				'-0000000000000001-01-01T00:00:00Z',
+				TimeValue::PRECISION_DAY,
 			),
 			'-00000000001-01-01T00:00:00Z (Gregorian)' => array(
-				new TimeValue(
-					'-0000000000000001-01-01T00:00:00Z',
-					0, 0, 0,
-					TimeValue::PRECISION_DAY,
-					$gregorian
-				),
+				'-0000000000000001-01-01T00:00:00Z',
+				TimeValue::PRECISION_DAY,
 			),
 			'-000001-01-01T00:00:00Z (Gregorian)' => array(
-				new TimeValue(
-					'-0000000000000001-01-01T00:00:00Z',
-					0, 0, 0,
-					TimeValue::PRECISION_DAY,
-					$gregorian
-				),
+				'-0000000000000001-01-01T00:00:00Z',
+				TimeValue::PRECISION_DAY,
 			),
 			'-1-01-01T00:00:00Z (Gregorian)' => array(
-				new TimeValue(
-					'-0000000000000001-01-01T00:00:00Z',
-					0, 0, 0,
-					TimeValue::PRECISION_DAY,
-					$gregorian
-				),
+				'-0000000000000001-01-01T00:00:00Z',
+				TimeValue::PRECISION_DAY,
 			),
 
 			// Tests with different options
 			'-1-01-02T00:00:00Z' => array(
-				new TimeValue(
-					'-0000000000000001-01-02T00:00:00Z',
-					0, 0, 0,
-					TimeValue::PRECISION_DAY,
-					$gregorian
-				),
+				'-0000000000000001-01-02T00:00:00Z',
+				TimeValue::PRECISION_DAY,
+				$gregorian,
 				$gregorianOpts,
 			),
 			'-1-01-03T00:00:00Z' => array(
-				new TimeValue(
-					'-0000000000000001-01-03T00:00:00Z',
-					0, 0, 0,
-					TimeValue::PRECISION_DAY,
-					$julian
-				),
+				'-0000000000000001-01-03T00:00:00Z',
+				TimeValue::PRECISION_DAY,
+				$julian,
 				$julianOpts,
 			),
 			'-1-01-04T00:00:00Z' => array(
-				new TimeValue(
-					'-0000000000000001-01-04T00:00:00Z',
-					0, 0, 0,
-					TimeValue::PRECISION_10a,
-					$gregorian
-				),
+				'-0000000000000001-01-04T00:00:00Z',
+				TimeValue::PRECISION_10a,
+				$gregorian,
 				$prec10aOpts,
 			),
 			'-1-01-05T00:00:00Z' => array(
-				new TimeValue(
-					'-0000000000000001-01-05T00:00:00Z',
-					0, 0, 0,
-					TimeValue::PRECISION_DAY,
-					$gregorian
-				),
+				'-0000000000000001-01-05T00:00:00Z',
+				TimeValue::PRECISION_DAY,
+				$gregorian,
 				$noPrecOpts,
 			),
 
 			'+1999-00-00T00:00:00Z' => array(
-				new TimeValue(
-					'+0000000000001999-00-00T00:00:00Z',
-					0, 0, 0,
-					TimeValue::PRECISION_YEAR,
-					$gregorian
-				),
+				'+0000000000001999-00-00T00:00:00Z',
+				TimeValue::PRECISION_YEAR,
 			),
 			'+2000-00-00T00:00:00Z' => array(
-				new TimeValue(
-					'+0000000000002000-00-00T00:00:00Z',
-					0, 0, 0,
-					TimeValue::PRECISION_YEAR,
-					$gregorian
-				),
+				'+0000000000002000-00-00T00:00:00Z',
+				TimeValue::PRECISION_YEAR,
 			),
 			'+2010-00-00T00:00:00Z' => array(
-				new TimeValue(
-					'+0000000000002010-00-00T00:00:00Z',
-					0, 0, 0,
-					TimeValue::PRECISION_YEAR,
-					$gregorian
-				),
+				'+0000000000002010-00-00T00:00:00Z',
+				TimeValue::PRECISION_YEAR,
 			),
 
 			// Optional sign character
 			'2015-01-01T00:00:00Z' => array(
-				new TimeValue(
-					'+0000000000002015-01-01T00:00:00Z',
-					0, 0, 0,
-					TimeValue::PRECISION_DAY,
-					TimeParser::CALENDAR_GREGORIAN
-				),
+				'+0000000000002015-01-01T00:00:00Z',
+				TimeValue::PRECISION_DAY,
 			),
 
 			// Optional time zone
 			'2015-01-01T00:00:00' => array(
-				new TimeValue(
-					'+0000000000002015-01-01T00:00:00Z',
-					0, 0, 0,
-					TimeValue::PRECISION_DAY,
-					TimeParser::CALENDAR_GREGORIAN
-				),
+				'+0000000000002015-01-01T00:00:00Z',
+				TimeValue::PRECISION_DAY,
 			),
 
 			// Actual minus character from Unicode; roundtrip with TimeDetailsFormatter
 			"\xE2\x88\x922015-01-01T00:00:00" => array(
-				new TimeValue(
-					'-0000000000002015-01-01T00:00:00Z',
-					0, 0, 0,
-					TimeValue::PRECISION_DAY,
-					TimeParser::CALENDAR_GREGORIAN
-				),
-				$noPrecOpts,
+				'-0000000000002015-01-01T00:00:00Z',
+				TimeValue::PRECISION_DAY,
 			),
 
 			// Optional second
 			'2015-01-01T00:00' => array(
-				new TimeValue(
-					'+0000000000002015-01-01T00:00:00Z',
-					0, 0, 0,
-					TimeValue::PRECISION_DAY,
-					TimeParser::CALENDAR_GREGORIAN
-				),
+				'+0000000000002015-01-01T00:00:00Z',
+				TimeValue::PRECISION_DAY,
 			),
 
 			// Optional hour and minute
 			'2015-01-01' => array(
-				new TimeValue(
-					'+0000000000002015-01-01T00:00:00Z',
-					0, 0, 0,
-					TimeValue::PRECISION_DAY,
-					TimeParser::CALENDAR_GREGORIAN
-				),
+				'+0000000000002015-01-01T00:00:00Z',
+				TimeValue::PRECISION_DAY,
 			),
 			'60-01-01' => array(
-				new TimeValue(
-					'+0000000000000060-01-01T00:00:00Z',
-					0, 0, 0,
-					TimeValue::PRECISION_DAY,
-					TimeFormatter::CALENDAR_GREGORIAN
-				),
-				$noPrecOpts,
+				'+0000000000000060-01-01T00:00:00Z',
+				TimeValue::PRECISION_DAY,
 			),
 
 			// Years < 60 require either the time part or a year with more than 2 digits
 			'1-01-01T00:00' => array(
-				new TimeValue(
-					'+0000000000000001-01-01T00:00:00Z',
-					0, 0, 0,
-					TimeValue::PRECISION_DAY,
-					TimeParser::CALENDAR_GREGORIAN
-				),
-				$noPrecOpts,
+				'+0000000000000001-01-01T00:00:00Z',
+				TimeValue::PRECISION_DAY,
 			),
 			'001-01-01' => array(
-				new TimeValue(
-					'+0000000000000001-01-01T00:00:00Z',
-					0, 0, 0,
-					TimeValue::PRECISION_DAY,
-					TimeFormatter::CALENDAR_GREGORIAN
-				),
-				$noPrecOpts,
+				'+0000000000000001-01-01T00:00:00Z',
+				TimeValue::PRECISION_DAY,
+
 			),
 
 			// Day zero
 			'2015-01-00' => array(
-				new TimeValue(
-					'+0000000000002015-01-00T00:00:00Z',
-					0, 0, 0,
-					TimeValue::PRECISION_MONTH,
-					TimeParser::CALENDAR_GREGORIAN
-				),
+				'+0000000000002015-01-00T00:00:00Z',
+				TimeValue::PRECISION_MONTH,
 			),
 
 			// Month zero
 			'2015-00-00' => array(
-				new TimeValue(
-					'+0000000000002015-00-00T00:00:00Z',
-					0, 0, 0,
-					TimeValue::PRECISION_YEAR,
-					TimeParser::CALENDAR_GREGORIAN
-				),
+				'+0000000000002015-00-00T00:00:00Z',
+				TimeValue::PRECISION_YEAR,
 			),
 
 			// Leap seconds are a valid concept
 			'+2015-01-01T00:00:60Z' => array(
-				new TimeValue(
-					'+0000000000002015-01-01T00:00:60Z',
-					0, 0, 0,
-					TimeValue::PRECISION_SECOND,
-					TimeParser::CALENDAR_GREGORIAN
-				),
+				'+0000000000002015-01-01T00:00:60Z',
+				TimeValue::PRECISION_SECOND,
 			),
 
 			// Tests for correct precision when a bad precision is passed through the opts
 			// @see https://bugzilla.wikimedia.org/show_bug.cgi?id=62730
 			'+0000000000000012-12-00T00:00:00Z' => array(
-				new TimeValue(
-					'+0000000000000012-12-00T00:00:00Z',
-					0, 0, 0,
-					TimeValue::PRECISION_MONTH,
-					$gregorian
-				),
+				'+0000000000000012-12-00T00:00:00Z',
+				TimeValue::PRECISION_MONTH,
+				$gregorian,
 				$precDayOpts,
 			),
 
@@ -457,13 +280,15 @@ class IsoTimestampParserTest extends ValueParserTestBase {
 
 		$argLists = array();
 		foreach ( $valid as $key => $value ) {
-			$timeValue = $value[0];
-			$options = isset( $value[1] ) ? $value[1] : null;
+			$timestamp = $value[0];
+			$precision = isset( $value[1] ) ? $value[1] : TimeValue::PRECISION_DAY;
+			$calendareModel = isset( $value[2] ) ? $value[2] : $gregorian;
+			$options = isset( $value[3] ) ? $value[3] : null;
 
 			$argLists[] = array(
 				// Because PHP magically turns numeric keys into ints/floats
 				(string)$key,
-				$timeValue,
+				new TimeValue( $timestamp, 0, 0, 0, $precision, $calendareModel ),
 				new IsoTimestampParser( new CalendarModelParser( $options ), $options )
 			);
 		}

--- a/tests/ValueParsers/IsoTimestampParserTest.php
+++ b/tests/ValueParsers/IsoTimestampParserTest.php
@@ -330,7 +330,6 @@ class IsoTimestampParserTest extends ValueParserTestBase {
 					TimeValue::PRECISION_DAY,
 					TimeParser::CALENDAR_GREGORIAN
 				),
-				$noPrecOpts,
 			),
 
 			// Optional time zone
@@ -341,7 +340,6 @@ class IsoTimestampParserTest extends ValueParserTestBase {
 					TimeValue::PRECISION_DAY,
 					TimeParser::CALENDAR_GREGORIAN
 				),
-				$noPrecOpts,
 			),
 
 			// Optional second
@@ -352,7 +350,6 @@ class IsoTimestampParserTest extends ValueParserTestBase {
 					TimeValue::PRECISION_DAY,
 					TimeParser::CALENDAR_GREGORIAN
 				),
-				$noPrecOpts,
 			),
 
 			// Optional hour and minute
@@ -363,7 +360,6 @@ class IsoTimestampParserTest extends ValueParserTestBase {
 					TimeValue::PRECISION_DAY,
 					TimeParser::CALENDAR_GREGORIAN
 				),
-				$noPrecOpts,
 			),
 
 			// Day zero
@@ -374,7 +370,6 @@ class IsoTimestampParserTest extends ValueParserTestBase {
 					TimeValue::PRECISION_MONTH,
 					TimeParser::CALENDAR_GREGORIAN
 				),
-				$noPrecOpts,
 			),
 
 			// Month zero
@@ -385,7 +380,16 @@ class IsoTimestampParserTest extends ValueParserTestBase {
 					TimeValue::PRECISION_YEAR,
 					TimeParser::CALENDAR_GREGORIAN
 				),
-				$noPrecOpts,
+			),
+
+			// Leap seconds are a valid concept
+			'+2015-01-01T00:00:60Z' => array(
+				new TimeValue(
+					'+0000000000002015-01-01T00:00:60Z',
+					0, 0, 0,
+					TimeValue::PRECISION_SECOND,
+					TimeParser::CALENDAR_GREGORIAN
+				),
 			),
 
 			// Tests for correct precision when a bad precision is passed through the opts
@@ -431,6 +435,10 @@ class IsoTimestampParserTest extends ValueParserTestBase {
 			array(),
 			'foooooooooo',
 			'1 June 2014',
+			'+2015-13-01T00:00:00Z',
+			'+2015-01-32T00:00:00Z',
+			'+2015-01-01T24:00:00Z',
+			'+2015-01-01T00:60:00Z',
 			'1234567890873',
 			2134567890
 		);

--- a/tests/ValueParsers/IsoTimestampParserTest.php
+++ b/tests/ValueParsers/IsoTimestampParserTest.php
@@ -322,6 +322,72 @@ class IsoTimestampParserTest extends ValueParserTestBase {
 				),
 			),
 
+			// Optional sign character
+			'2015-01-01T00:00:00Z' => array(
+				new TimeValue(
+					'+0000000000002015-01-01T00:00:00Z',
+					0, 0, 0,
+					TimeValue::PRECISION_DAY,
+					TimeParser::CALENDAR_GREGORIAN
+				),
+				$noPrecOpts,
+			),
+
+			// Optional time zone
+			'2015-01-01T00:00:00' => array(
+				new TimeValue(
+					'+0000000000002015-01-01T00:00:00Z',
+					0, 0, 0,
+					TimeValue::PRECISION_DAY,
+					TimeParser::CALENDAR_GREGORIAN
+				),
+				$noPrecOpts,
+			),
+
+			// Optional second
+			'2015-01-01T00:00' => array(
+				new TimeValue(
+					'+0000000000002015-01-01T00:00:00Z',
+					0, 0, 0,
+					TimeValue::PRECISION_DAY,
+					TimeParser::CALENDAR_GREGORIAN
+				),
+				$noPrecOpts,
+			),
+
+			// Optional hour and minute
+			'2015-01-01' => array(
+				new TimeValue(
+					'+0000000000002015-01-01T00:00:00Z',
+					0, 0, 0,
+					TimeValue::PRECISION_DAY,
+					TimeParser::CALENDAR_GREGORIAN
+				),
+				$noPrecOpts,
+			),
+
+			// Day zero
+			'2015-01-00' => array(
+				new TimeValue(
+					'+0000000000002015-01-00T00:00:00Z',
+					0, 0, 0,
+					TimeValue::PRECISION_MONTH,
+					TimeParser::CALENDAR_GREGORIAN
+				),
+				$noPrecOpts,
+			),
+
+			// Month zero
+			'2015-00-00' => array(
+				new TimeValue(
+					'+0000000000002015-00-00T00:00:00Z',
+					0, 0, 0,
+					TimeValue::PRECISION_YEAR,
+					TimeParser::CALENDAR_GREGORIAN
+				),
+				$noPrecOpts,
+			),
+
 			// Tests for correct precision when a bad precision is passed through the opts
 			// @see https://bugzilla.wikimedia.org/show_bug.cgi?id=62730
 			'+0000000000000012-12-00T00:00:00Z' => array(

--- a/tests/ValueParsers/IsoTimestampParserTest.php
+++ b/tests/ValueParsers/IsoTimestampParserTest.php
@@ -362,6 +362,19 @@ class IsoTimestampParserTest extends ValueParserTestBase {
 				),
 			),
 
+			// Years < 59 require at least hour and minute
+			'1-01-01T00:00' => array(
+				TimeValue::newFromArray( array(
+					'time' => '+0000000000000001-01-01T00:00:00Z',
+					'timezone' => 0,
+					'before' => 0,
+					'after' => 0,
+					'precision' => TimeValue::PRECISION_DAY,
+					'calendarmodel' => TimeFormatter::CALENDAR_GREGORIAN
+				) ),
+				$noPrecOpts,
+			),
+
 			// Day zero
 			'2015-01-00' => array(
 				new TimeValue(
@@ -435,10 +448,13 @@ class IsoTimestampParserTest extends ValueParserTestBase {
 			array(),
 			'foooooooooo',
 			'1 June 2014',
+			'59-01-01',
+			'+59-01-01',
 			'+2015-13-01T00:00:00Z',
 			'+2015-01-32T00:00:00Z',
 			'+2015-01-01T24:00:00Z',
 			'+2015-01-01T00:60:00Z',
+			'+2015-01-01T00:00:63Z',
 			'1234567890873',
 			2134567890
 		);

--- a/tests/ValueParsers/IsoTimestampParserTest.php
+++ b/tests/ValueParsers/IsoTimestampParserTest.php
@@ -82,6 +82,15 @@ class IsoTimestampParserTest extends ValueParserTestBase {
 					$gregorian
 				),
 			),
+			'+0000000000000000-00-00T00:00:00Z' => array(
+				new TimeValue(
+					'+0000000000000000-00-00T00:00:00Z',
+					0, 0, 0,
+					TimeValue::PRECISION_YEAR,
+					TimeFormatter::CALENDAR_GREGORIAN
+				),
+				$emptyOpts,
+			),
 			'+0000000000002000-00-00T00:00:00Z' => array(
 				new TimeValue(
 					'+0000000000002000-00-00T00:00:00Z',
@@ -372,14 +381,32 @@ class IsoTimestampParserTest extends ValueParserTestBase {
 					TimeParser::CALENDAR_GREGORIAN
 				),
 			),
+			'60-01-01' => array(
+				new TimeValue(
+					'+0000000000000060-01-01T00:00:00Z',
+					0, 0, 0,
+					TimeValue::PRECISION_DAY,
+					TimeFormatter::CALENDAR_GREGORIAN
+				),
+				$noPrecOpts,
+			),
 
-			// Years < 59 require at least hour and minute
+			// Years < 60 require either the time part or a year with more than 2 digits
 			'1-01-01T00:00' => array(
 				new TimeValue(
 					'+0000000000000001-01-01T00:00:00Z',
 					0, 0, 0,
 					TimeValue::PRECISION_DAY,
 					TimeParser::CALENDAR_GREGORIAN
+				),
+				$noPrecOpts,
+			),
+			'001-01-01' => array(
+				new TimeValue(
+					'+0000000000000001-01-01T00:00:00Z',
+					0, 0, 0,
+					TimeValue::PRECISION_DAY,
+					TimeFormatter::CALENDAR_GREGORIAN
 				),
 				$noPrecOpts,
 			),

--- a/tests/ValueParsers/IsoTimestampParserTest.php
+++ b/tests/ValueParsers/IsoTimestampParserTest.php
@@ -348,7 +348,7 @@ class IsoTimestampParserTest extends ValueParserTestBase {
 					'-0000000000002015-01-01T00:00:00Z',
 					0, 0, 0,
 					TimeValue::PRECISION_DAY,
-					TimeFormatter::CALENDAR_GREGORIAN
+					TimeParser::CALENDAR_GREGORIAN
 				),
 				$noPrecOpts,
 			),
@@ -375,14 +375,12 @@ class IsoTimestampParserTest extends ValueParserTestBase {
 
 			// Years < 59 require at least hour and minute
 			'1-01-01T00:00' => array(
-				TimeValue::newFromArray( array(
-					'time' => '+0000000000000001-01-01T00:00:00Z',
-					'timezone' => 0,
-					'before' => 0,
-					'after' => 0,
-					'precision' => TimeValue::PRECISION_DAY,
-					'calendarmodel' => TimeFormatter::CALENDAR_GREGORIAN
-				) ),
+				new TimeValue(
+					'+0000000000000001-01-01T00:00:00Z',
+					0, 0, 0,
+					TimeValue::PRECISION_DAY,
+					TimeParser::CALENDAR_GREGORIAN
+				),
 				$noPrecOpts,
 			),
 


### PR DESCRIPTION
This is a major rewrite of the TimeParser class. The main change is: Most elements in the ISO time string are now optional (see the added test cases). All other changes are refactoring without changing functionality.

Bug: [T87574](https://phabricator.wikimedia.org/T87574)