### PR TITLE
Remove composer update from bootstrap

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,9 +4,11 @@ if ( PHP_SAPI !== 'cli' ) {
 	die( 'Not an entry point' );
 }
 
-$pwd = getcwd();
-chdir( __DIR__ . '/..' );
-passthru( 'composer update' );
-chdir( $pwd );
+error_reporting( E_ALL | E_STRICT );
+ini_set( 'display_errors', 1 );
+
+if ( !is_readable( __DIR__ . '/../vendor/autoload.php' ) ) {
+	die( 'You need to install this package with Composer before you can run the tests' );
+}
 
 require_once( __DIR__ . '/../vendor/autoload.php' );


### PR DESCRIPTION
As done in several components now. The command depends on external services and can take a lot of time.