### PR TITLE
Do not always show "(Gregorian)" suffix

### DIFF
--- a/src/ValueFormatters/TimeFormatter.php
+++ b/src/ValueFormatters/TimeFormatter.php
@@ -17,11 +17,10 @@ use InvalidArgumentException;
  * @author H. Snater < mediawiki@snater.com >
  */
 class TimeFormatter extends ValueFormatterBase {
+
 	const CALENDAR_GREGORIAN = 'http://www.wikidata.org/entity/Q1985727';
 	const CALENDAR_JULIAN = 'http://www.wikidata.org/entity/Q1985786';
 
-	const OPT_LANGUAGE = 'language';
-	const OPT_CALENDARNAMES = 'calendars';
 	const OPT_TIME_ISO_FORMATTER = 'time iso formatter';
 
 	/**
@@ -31,13 +30,6 @@ class TimeFormatter extends ValueFormatterBase {
 	 */
 	public function __construct( FormatterOptions $options ) {
 		parent::__construct( $options );
-
-		$this->defaultOption( self::OPT_LANGUAGE, null );
-
-		$this->defaultOption( self::OPT_CALENDARNAMES, array(
-			self::CALENDAR_GREGORIAN => 'Gregorian',
-			self::CALENDAR_JULIAN => 'Julian',
-		) );
 
 		$this->defaultOption( self::OPT_TIME_ISO_FORMATTER, null );
 	}
@@ -68,10 +60,7 @@ class TimeFormatter extends ValueFormatterBase {
 			);
 		}
 
-		$calendarNames = $this->getOption( self::OPT_CALENDARNAMES );
-
-		// TODO: Support other calendar models retrieved via $value->getCalendarModel().
-		return $formatted . ' (' . $calendarNames[self::CALENDAR_GREGORIAN] . ')';
+		return $formatted;
 	}
 
 }

--- a/tests/ValueFormatters/TimeFormatterTest.php
+++ b/tests/ValueFormatters/TimeFormatterTest.php
@@ -26,7 +26,7 @@ class TimeFormatterTest extends ValueFormatterTestBase {
 	 */
 	public function validProvider() {
 		$tests = array(
-			'+00000002013-07-16T00:00:00Z (Gregorian)' => array(
+			'+00000002013-07-16T00:00:00Z' => array(
 				'+00000002013-07-16T00:00:00Z',
 				0,
 				0,
@@ -34,7 +34,7 @@ class TimeFormatterTest extends ValueFormatterTestBase {
 				11,
 				TimeFormatter::CALENDAR_GREGORIAN
 			),
-			'+00000000000-01-01T00:00:00Z (Gregorian)' => array(
+			'+00000000000-01-01T00:00:00Z' => array(
 				'+00000000000-01-01T00:00:00Z',
 				0,
 				0,
@@ -42,7 +42,7 @@ class TimeFormatterTest extends ValueFormatterTestBase {
 				11,
 				TimeFormatter::CALENDAR_GREGORIAN
 			),
-			'+00000000001-01-14T00:00:00Z (Gregorian)' => array(
+			'+00000000001-01-14T00:00:00Z' => array(
 				'+00000000001-01-14T00:00:00Z',
 				0,
 				0,
@@ -50,7 +50,7 @@ class TimeFormatterTest extends ValueFormatterTestBase {
 				11,
 				TimeFormatter::CALENDAR_JULIAN
 			),
-			'+00000010000-01-01T00:00:00Z (Gregorian)' => array(
+			'+00000010000-01-01T00:00:00Z' => array(
 				'+00000010000-01-01T00:00:00Z',
 				0,
 				0,
@@ -58,7 +58,7 @@ class TimeFormatterTest extends ValueFormatterTestBase {
 				11,
 				TimeFormatter::CALENDAR_GREGORIAN
 			),
-			'-00000000001-01-01T00:00:00Z (Gregorian)' => array(
+			'-00000000001-01-01T00:00:00Z' => array(
 				'-00000000001-01-01T00:00:00Z',
 				0,
 				0,
@@ -66,7 +66,7 @@ class TimeFormatterTest extends ValueFormatterTestBase {
 				11,
 				TimeFormatter::CALENDAR_GREGORIAN
 			),
-			'+00000002013-07-17T00:00:00Z (Gregorian)' => array(
+			'+00000002013-07-17T00:00:00Z' => array(
 				'+00000002013-07-17T00:00:00Z',
 				0,
 				0,
@@ -74,7 +74,7 @@ class TimeFormatterTest extends ValueFormatterTestBase {
 				10,
 				TimeFormatter::CALENDAR_GREGORIAN
 			),
-			'+00000002013-07-18T00:00:00Z (Gregorian)' => array(
+			'+00000002013-07-18T00:00:00Z' => array(
 				'+00000002013-07-18T00:00:00Z',
 				0,
 				0,
@@ -82,7 +82,7 @@ class TimeFormatterTest extends ValueFormatterTestBase {
 				9,
 				TimeFormatter::CALENDAR_GREGORIAN
 			),
-			'+00000002013-07-19T00:00:00Z (Gregorian)' => array(
+			'+00000002013-07-19T00:00:00Z' => array(
 				'+00000002013-07-19T00:00:00Z',
 				0,
 				0,


### PR DESCRIPTION
This patch simply removes the appended "... (Gregorian)". This was only visible in diff views, but confusing and just not necessary there, because the TimeDetailsFormatter shows the calendar model anyway. Note that it **always** displayed "Gregorian".

~~Warning: If this patch is going in the right direction depends on the outcome of the discussion at [T88437](https://phabricator.wikimedia.org/T88437).~~

Bug: ~~[T87312](https://phabricator.wikimedia.org/T87312)~~ [T92265](https://phabricator.wikimedia.org/T92265)