### PR TITLE
Enforce minimal year padding to 4 digits

### DIFF
--- a/src/DataValues/TimeValue.php
+++ b/src/DataValues/TimeValue.php
@@ -35,7 +35,7 @@ class TimeValue extends DataValueObject {
 	 *
 	 * Gregorian and Julian dates use the same YMD ordered format, resembling ISO 8601, e.g.
 	 * +2013-01-01T00:00:00Z. In this format the year is always signed and padded with zero
-	 * characters to have between 1 and 16 digits. Month and day can be zero, indicating they are
+	 * characters to have between 4 and 16 digits. Month and day can be zero, indicating they are
 	 * unknown. The timezone suffix Z is meaningless and must be ignored. Use $timezone instead.
 	 *
 	 * @see $timezone
@@ -102,7 +102,11 @@ class TimeValue extends DataValueObject {
 		}
 
 		// Leap seconds are a valid concept
-		if ( !preg_match( '!^[-+]\d{1,16}-(0\d|1[012])-([012]\d|3[01])T([01]\d|2[0123]):[0-5]\d:([0-5]\d|6[012])Z$!', $time ) ) {
+		if ( !preg_match(
+			'/^([-+])(\d{1,16})(-(?:0\d|1[012])-(?:[012]\d|3[01])T(?:[01]\d|2[0-3]):[0-5]\d:(?:[0-5]\d|6[012])Z)$/',
+			$time,
+			$matches
+		) ) {
 			throw new IllegalValueException( '$time must be a YMD string resembling ISO 8601, given ' . $time );
 		}
 
@@ -135,7 +139,10 @@ class TimeValue extends DataValueObject {
 			throw new IllegalValueException( '$calendarModel must be a non-empty string' );
 		}
 
-		$this->time = $time;
+		$year = $matches[2];
+		$year = str_pad( $year, 4, '0', STR_PAD_LEFT );
+
+		$this->time = $matches[1] . $year . $matches[3];
 		$this->timezone = $timezone;
 		$this->before = $before;
 		$this->after = $after;

--- a/tests/DataValues/TimeValueTest.php
+++ b/tests/DataValues/TimeValueTest.php
@@ -12,6 +12,7 @@ use DataValues\TimeValue;
  *
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ * @author Thiemo Mättig
  */
 class TimeValueTest extends DataValueTest {
 
@@ -66,7 +67,7 @@ class TimeValueTest extends DataValueTest {
 		);
 
 		$argLists[] = array(
-			'-5-01-01T00:00:00Z',
+			'-0005-01-01T00:00:00Z',
 			0,
 			0,
 			0,
@@ -224,6 +225,13 @@ class TimeValueTest extends DataValueTest {
 			'http://nyan.cat/original.php',
 		);
 
+		$argLists[] = array(
+			'+00000000000000001-01-01T00:00:00Z',
+			0, 0, 0,
+			TimeValue::PRECISION_DAY,
+			'http://nyan.cat/original.php',
+		);
+
 		return $argLists;
 	}
 
@@ -288,6 +296,31 @@ class TimeValueTest extends DataValueTest {
 	 */
 	public function testGetValue( TimeValue $time, array $arguments ) {
 		$this->assertTrue( $time->equals( $time->getValue() ) );
+	}
+
+	/**
+	 * @dataProvider unpaddedYearsProvider
+	 * @param string $year
+	 * @param string $expected
+	 */
+	public function testGivenUnpaddedYear_yearIsPadded( $year, $expected ) {
+		$timeValue = new TimeValue(
+			$year . '-01-01T00:00:00Z',
+			0, 0, 0,
+			TimeValue::PRECISION_DAY,
+			'Stardate'
+		);
+		$this->assertSame( $expected . '-01-01T00:00:00Z', $timeValue->getTime() );
+	}
+
+	public function unpaddedYearsProvider() {
+		return array(
+			array( '+1', '+0001' ),
+			array( '-10', '-0010' ),
+			array( '+2015', '+2015' ),
+			array( '+0000000000000001', '+0000000000000001' ),
+			array( '+9999999999999999', '+9999999999999999' ),
+		);
 	}
 
 }

--- a/tests/DataValues/TimeValueTest.php
+++ b/tests/DataValues/TimeValueTest.php
@@ -28,211 +28,145 @@ class TimeValueTest extends DataValueTest {
 	}
 
 	public function validConstructorArgumentsProvider() {
-		$argLists = array();
-
-		$argLists[] = array(
-			'+00000002013-01-01T00:00:00Z',
-			0,
-			0,
-			0,
-			TimeValue::PRECISION_SECOND,
-			'http://nyan.cat/original.php',
+		return array(
+			array(
+				'+00000002013-01-01T00:00:00Z',
+				0, 0, 0,
+				TimeValue::PRECISION_SECOND,
+				'http://nyan.cat/original.php',
+			),
+			array(
+				'+00000002013-01-01T00:00:00Z',
+				7200, 9001, 9001,
+				TimeValue::PRECISION_Ga,
+				'http://nyan.cat/original.php',
+			),
+			array(
+				'+00000002013-01-01T00:00:00Z',
+				-7200, 0, 42,
+				TimeValue::PRECISION_YEAR,
+				'http://nyan.cat/original.php',
+			),
+			array(
+				'+2013-01-01T00:00:00Z',
+				0, 0, 0,
+				TimeValue::PRECISION_SECOND,
+				'http://nyan.cat/original.php',
+			),
+			array(
+				'-0005-01-01T00:00:00Z',
+				0, 0, 0,
+				TimeValue::PRECISION_SECOND,
+				'http://nyan.cat/original.php',
+			)
 		);
-
-		$argLists[] = array(
-			'+00000002013-01-01T00:00:00Z',
-			7200,
-			9001,
-			9001,
-			TimeValue::PRECISION_Ga,
-			'http://nyan.cat/original.php',
-		);
-
-		$argLists[] = array(
-			'+00000002013-01-01T00:00:00Z',
-			-7200,
-			0,
-			42,
-			TimeValue::PRECISION_YEAR,
-			'http://nyan.cat/original.php',
-		);
-
-		$argLists[] = array(
-			'+2013-01-01T00:00:00Z',
-			0,
-			0,
-			0,
-			TimeValue::PRECISION_SECOND,
-			'http://nyan.cat/original.php',
-		);
-
-		$argLists[] = array(
-			'-0005-01-01T00:00:00Z',
-			0,
-			0,
-			0,
-			TimeValue::PRECISION_SECOND,
-			'http://nyan.cat/original.php',
-		);
-
-		return $argLists;
 	}
 
 	public function invalidConstructorArgumentsProvider() {
-		$argLists = array();
-
-		$argLists[] = array(
-			'+00000002013-01-01T00:00:00Z',
-			'0',
-			0,
-			0,
-			TimeValue::PRECISION_SECOND,
-			'http://nyan.cat/original.php',
+		return array(
+			array(
+				'+00000002013-01-01T00:00:00Z',
+				'0', 0, 0,
+				TimeValue::PRECISION_SECOND,
+				'http://nyan.cat/original.php',
+			),
+			array(
+				'+00000002013-01-01T00:00:00Z',
+				4.2, 0, 0,
+				TimeValue::PRECISION_SECOND,
+				'http://nyan.cat/original.php',
+			),
+			array(
+				'+00000002013-01-01T00:00:00Z',
+				-20 * 3600, 0, 0,
+				TimeValue::PRECISION_SECOND,
+				'http://nyan.cat/original.php',
+			),
+			array(
+				'+00000002013-01-01T00:00:00Z',
+				0, 0, 0,
+				333,
+				'http://nyan.cat/original.php',
+			),
+			array(
+				'+00000002013-01-01T00:00:00Z',
+				0, 0, 0,
+				9001,
+				'http://nyan.cat/original.php',
+			),
+			array(
+				42,
+				0, 0, 0,
+				TimeValue::PRECISION_SECOND,
+				'http://nyan.cat/original.php',
+			),
+			array(
+				'+00000002013-01-01T00:00:00Z',
+				0, 4.2, 0,
+				TimeValue::PRECISION_SECOND,
+				'http://nyan.cat/original.php',
+			),
+			array(
+				'+00000002013-01-01T00:00:00Z',
+				0, 0, -1,
+				TimeValue::PRECISION_SECOND,
+				'http://nyan.cat/original.php',
+			),
+			array(
+				'bla',
+				0, 0, 0,
+				TimeValue::PRECISION_SECOND,
+				'http://nyan.cat/original.php',
+			),
+			array(
+				'+00000002013/01/01 00:00:00',
+				0, 0, 0,
+				TimeValue::PRECISION_SECOND,
+				'http://nyan.cat/original.php',
+			),
+			array(
+				'+00000002013-22-01T00:00:00Z',
+				0, 0, 0,
+				TimeValue::PRECISION_SECOND,
+				'http://nyan.cat/original.php',
+			),
+			array(
+				'+00000002013-01-35T00:00:00Z',
+				0, 0, 0,
+				TimeValue::PRECISION_SECOND,
+				'http://nyan.cat/original.php',
+			),
+			array(
+				'+00000002013-01-01T27:00:00Z',
+				0, 0, 0,
+				TimeValue::PRECISION_SECOND,
+				'http://nyan.cat/original.php',
+			),
+			array(
+				'+00000002013-01-01T00:66:00Z',
+				0, 0, 0,
+				TimeValue::PRECISION_SECOND,
+				'http://nyan.cat/original.php',
+			),
+			array(
+				'+00000002013-01-01T00:00:66Z',
+				0, 0, 0,
+				TimeValue::PRECISION_SECOND,
+				'http://nyan.cat/original.php',
+			),
+			array(
+				'+00000002013-01-01T00:00:00+60',
+				0, 0, 0,
+				TimeValue::PRECISION_SECOND,
+				'http://nyan.cat/original.php',
+			),
+			array(
+				'+00000000000000001-01-01T00:00:00Z',
+				0, 0, 0,
+				TimeValue::PRECISION_DAY,
+				'http://nyan.cat/original.php',
+			)
 		);
-
-		$argLists[] = array(
-			'+00000002013-01-01T00:00:00Z',
-			4.2,
-			0,
-			0,
-			TimeValue::PRECISION_SECOND,
-			'http://nyan.cat/original.php',
-		);
-
-		$argLists[] = array(
-			'+00000002013-01-01T00:00:00Z',
-			-20 * 3600,
-			0,
-			0,
-			TimeValue::PRECISION_SECOND,
-			'http://nyan.cat/original.php',
-		);
-
-		$argLists[] = array(
-			'+00000002013-01-01T00:00:00Z',
-			0,
-			0,
-			0,
-			333,
-			'http://nyan.cat/original.php',
-		);
-
-		$argLists[] = array(
-			'+00000002013-01-01T00:00:00Z',
-			0,
-			0,
-			0,
-			9001,
-			'http://nyan.cat/original.php',
-		);
-
-		$argLists[] = array(
-			42,
-			0,
-			0,
-			0,
-			TimeValue::PRECISION_SECOND,
-			'http://nyan.cat/original.php',
-		);
-
-		$argLists[] = array(
-			'+00000002013-01-01T00:00:00Z',
-			0,
-			4.2,
-			0,
-			TimeValue::PRECISION_SECOND,
-			'http://nyan.cat/original.php',
-		);
-
-		$argLists[] = array(
-			'+00000002013-01-01T00:00:00Z',
-			0,
-			0,
-			-1,
-			TimeValue::PRECISION_SECOND,
-			'http://nyan.cat/original.php',
-		);
-
-		$argLists[] = array(
-			'bla',
-			0,
-			0,
-			0,
-			TimeValue::PRECISION_SECOND,
-			'http://nyan.cat/original.php',
-		);
-
-		$argLists[] = array(
-			'+00000002013/01/01 00:00:00',
-			0,
-			0,
-			0,
-			TimeValue::PRECISION_SECOND,
-			'http://nyan.cat/original.php',
-		);
-
-		$argLists[] = array(
-			'+00000002013-22-01T00:00:00Z',
-			0,
-			0,
-			0,
-			TimeValue::PRECISION_SECOND,
-			'http://nyan.cat/original.php',
-		);
-
-		$argLists[] = array(
-			'+00000002013-01-35T00:00:00Z',
-			0,
-			0,
-			0,
-			TimeValue::PRECISION_SECOND,
-			'http://nyan.cat/original.php',
-		);
-
-		$argLists[] = array(
-			'+00000002013-01-01T27:00:00Z',
-			0,
-			0,
-			0,
-			TimeValue::PRECISION_SECOND,
-			'http://nyan.cat/original.php',
-		);
-
-		$argLists[] = array(
-			'+00000002013-01-01T00:66:00Z',
-			0,
-			0,
-			0,
-			TimeValue::PRECISION_SECOND,
-			'http://nyan.cat/original.php',
-		);
-
-		$argLists[] = array(
-			'+00000002013-01-01T00:00:66Z',
-			0,
-			0,
-			0,
-			TimeValue::PRECISION_SECOND,
-			'http://nyan.cat/original.php',
-		);
-
-		$argLists[] = array(
-			'+00000002013-01-01T00:00:00+60',
-			0,
-			0,
-			0,
-			TimeValue::PRECISION_SECOND,
-			'http://nyan.cat/original.php',
-		);
-
-		$argLists[] = array(
-			'+00000000000000001-01-01T00:00:00Z',
-			0, 0, 0,
-			TimeValue::PRECISION_DAY,
-			'http://nyan.cat/original.php',
-		);
-
-		return $argLists;
 	}
 
 	/**


### PR DESCRIPTION
This implements an enforced padding to 4 digits for the year. This is the most minimal compromise. Look at how the `DateTimeParser` is implemented: It uses PHP's internal DateTime parser and needs to pad (and cut) the year to 4 digits to do this. An enforced padding to 4 digits is not crucial in this class but very convenient for almost all (external) use cases.

We can easily increase this to 16 digits later, depending on the outcome of the discussion at [T66084](https://phabricator.wikimedia.org/T66084) and related Phabricator tasks.

This also adds a test to ensure more than 16 digits for the year are not accepted.

The 1st commit is crucial, the 2nd is only a style change.

Bug: [T66084](https://phabricator.wikimedia.org/T66084)