### PR TITLE
Rename TimeParser to IsoTimestampParser

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ DataValues Time has been written by the Wikidata team, as [Wikimedia Germany]
 * The year in Gregorian and Julian `TimeValue`s is now padded to at least 4 digits
 * Empty strings are now detected as invalid calendar models in the `TimeValue` constructor
 * Major update of the `TimeValue` documentation
-* Constructor arguments in `TimeParser` are optional now
+* Renamed `TimeParser` to `IsoTimestampParser`
+* Constructor arguments in `IsoTimestampParser` are optional now
 * Fixed `TimeFormatter` delegating to an ISO timestamp formatter given via option
 
 ### 0.6.1 (2014-10-09)

--- a/src/ValueParsers/IsoTimestampParser.php
+++ b/src/ValueParsers/IsoTimestampParser.php
@@ -7,26 +7,23 @@ use DataValues\TimeValue;
 use InvalidArgumentException;
 
 /**
- * ValueParser that parses the string representation of a time.
+ * ValueParser that parses YMD ordered timestamp strings resembling ISO 8601, e.g.
+ * +2013-01-01T00:00:00Z. While the parser tries to be relaxed, certain aspects of the ISO norm are
+ * obligatory: The order must be YMD. All elements but the year must have 2 digits. The seperation
+ * characters must be dashes (in the date part), "T" and colons (in the time part).
  *
- * @since 0.2
+ * @since 0.7
  *
  * @licence GNU GPL v2+
  * @author Adam Shorland
  */
-class TimeParser extends StringValueParser {
+class IsoTimestampParser extends StringValueParser {
 
 	const FORMAT_NAME = 'time';
 
-	/**
-	 * @since 0.3
-	 */
 	const OPT_PRECISION = 'precision';
 	const OPT_CALENDAR = 'calendar';
 
-	/**
-	 * @since 0.3
-	 */
 	const CALENDAR_GREGORIAN = 'http://www.wikidata.org/entity/Q1985727';
 	const CALENDAR_JULIAN = 'http://www.wikidata.org/entity/Q1985786';
 	const PRECISION_NONE = 'noprecision';
@@ -37,8 +34,6 @@ class TimeParser extends StringValueParser {
 	private $calendarModelParser;
 
 	/**
-	 * @since 0.1
-	 *
 	 * @param CalendarModelParser|null $calendarModelParser
 	 * @param ParserOptions|null $options
 	 */

--- a/tests/ValueParsers/IsoTimestampParserTest.php
+++ b/tests/ValueParsers/IsoTimestampParserTest.php
@@ -4,11 +4,11 @@ namespace ValueParsers\Test;
 
 use DataValues\TimeValue;
 use ValueParsers\CalendarModelParser;
+use ValueParsers\IsoTimestampParser;
 use ValueParsers\ParserOptions;
-use ValueParsers\TimeParser;
 
 /**
- * @covers \ValueParsers\TimeParser
+ * @covers ValueParsers\IsoTimestampParser
  *
  * @group DataValue
  * @group DataValueExtensions
@@ -16,7 +16,7 @@ use ValueParsers\TimeParser;
  * @author Adam Shorland
  * @author Thiemo Mättig
  */
-class TimeParserTest extends ValueParserTestBase {
+class IsoTimestampParserTest extends ValueParserTestBase {
 
 	/**
 	 * @deprecated since 0.3, just use getInstance.
@@ -28,30 +28,33 @@ class TimeParserTest extends ValueParserTestBase {
 	/**
 	 * @see ValueParserTestBase::getInstance
 	 *
-	 * @return TimeParser
+	 * @return IsoTimestampParser
 	 */
 	protected function getInstance() {
-		return new TimeParser();
+		return new IsoTimestampParser();
 	}
 
 	/**
 	 * @see ValueParserTestBase::validInputProvider
 	 */
 	public function validInputProvider() {
+		$gregorian = 'http://www.wikidata.org/entity/Q1985727';
+		$julian = 'http://www.wikidata.org/entity/Q1985786';
+
 		$julianOpts = new ParserOptions();
-		$julianOpts->setOption( TimeParser::OPT_CALENDAR, TimeParser::CALENDAR_JULIAN );
+		$julianOpts->setOption( IsoTimestampParser::OPT_CALENDAR, $julian );
 
 		$gregorianOpts = new ParserOptions();
-		$gregorianOpts->setOption( TimeParser::OPT_CALENDAR, TimeParser::CALENDAR_GREGORIAN );
+		$gregorianOpts->setOption( IsoTimestampParser::OPT_CALENDAR, $gregorian );
 
 		$prec10aOpts = new ParserOptions();
-		$prec10aOpts->setOption( TimeParser::OPT_PRECISION, TimeValue::PRECISION_10a );
+		$prec10aOpts->setOption( IsoTimestampParser::OPT_PRECISION, TimeValue::PRECISION_10a );
 
 		$precDayOpts = new ParserOptions();
-		$precDayOpts->setOption( TimeParser::OPT_PRECISION, TimeValue::PRECISION_DAY );
+		$precDayOpts->setOption( IsoTimestampParser::OPT_PRECISION, TimeValue::PRECISION_DAY );
 
 		$noPrecOpts = new ParserOptions();
-		$noPrecOpts->setOption( TimeParser::OPT_PRECISION, TimeParser::PRECISION_NONE );
+		$noPrecOpts->setOption( IsoTimestampParser::OPT_PRECISION, IsoTimestampParser::PRECISION_NONE );
 
 		$valid = array(
 			// Empty options tests
@@ -60,7 +63,7 @@ class TimeParserTest extends ValueParserTestBase {
 					'+0000000000002013-07-16T00:00:00Z',
 					0, 0, 0,
 					TimeValue::PRECISION_DAY,
-					TimeParser::CALENDAR_GREGORIAN
+					$gregorian
 				),
 			),
 			'+0000000000002013-07-00T00:00:00Z' => array(
@@ -68,7 +71,7 @@ class TimeParserTest extends ValueParserTestBase {
 					'+0000000000002013-07-00T00:00:00Z',
 					0, 0, 0,
 					TimeValue::PRECISION_MONTH,
-					TimeParser::CALENDAR_GREGORIAN
+					$gregorian
 				),
 			),
 			'+0000000000002013-00-00T00:00:00Z' => array(
@@ -76,7 +79,7 @@ class TimeParserTest extends ValueParserTestBase {
 					'+0000000000002013-00-00T00:00:00Z',
 					0, 0, 0,
 					TimeValue::PRECISION_YEAR,
-					TimeParser::CALENDAR_GREGORIAN
+					$gregorian
 				),
 			),
 			'+0000000000002000-00-00T00:00:00Z' => array(
@@ -84,7 +87,7 @@ class TimeParserTest extends ValueParserTestBase {
 					'+0000000000002000-00-00T00:00:00Z',
 					0, 0, 0,
 					TimeValue::PRECISION_YEAR,
-					TimeParser::CALENDAR_GREGORIAN
+					$gregorian
 				),
 			),
 			'+0000000000008000-00-00T00:00:00Z' => array(
@@ -92,7 +95,7 @@ class TimeParserTest extends ValueParserTestBase {
 					'+0000000000008000-00-00T00:00:00Z',
 					0, 0, 0,
 					TimeValue::PRECISION_ka,
-					TimeParser::CALENDAR_GREGORIAN
+					$gregorian
 				),
 			),
 			'+0000000000020000-00-00T00:00:00Z' => array(
@@ -100,7 +103,7 @@ class TimeParserTest extends ValueParserTestBase {
 					'+0000000000020000-00-00T00:00:00Z',
 					0, 0, 0,
 					TimeValue::PRECISION_10ka,
-					TimeParser::CALENDAR_GREGORIAN
+					$gregorian
 				),
 			),
 			'+0000000000200000-00-00T00:00:00Z' => array(
@@ -108,7 +111,7 @@ class TimeParserTest extends ValueParserTestBase {
 					'+0000000000200000-00-00T00:00:00Z',
 					0, 0, 0,
 					TimeValue::PRECISION_100ka,
-					TimeParser::CALENDAR_GREGORIAN
+					$gregorian
 				),
 			),
 			'+0000000002000000-00-00T00:00:00Z' => array(
@@ -116,7 +119,7 @@ class TimeParserTest extends ValueParserTestBase {
 					'+0000000002000000-00-00T00:00:00Z',
 					0, 0, 0,
 					TimeValue::PRECISION_Ma,
-					TimeParser::CALENDAR_GREGORIAN
+					$gregorian
 				),
 			),
 			'+0000000020000000-00-00T00:00:00Z' => array(
@@ -124,7 +127,7 @@ class TimeParserTest extends ValueParserTestBase {
 					'+0000000020000000-00-00T00:00:00Z',
 					0, 0, 0,
 					TimeValue::PRECISION_10Ma,
-					TimeParser::CALENDAR_GREGORIAN
+					$gregorian
 				),
 			),
 			'+0000000200000000-00-00T00:00:00Z' => array(
@@ -132,7 +135,7 @@ class TimeParserTest extends ValueParserTestBase {
 					'+0000000200000000-00-00T00:00:00Z',
 					0, 0, 0,
 					TimeValue::PRECISION_100Ma,
-					TimeParser::CALENDAR_GREGORIAN
+					$gregorian
 				),
 			),
 			'+0000002000000000-00-00T00:00:00Z' => array(
@@ -140,7 +143,7 @@ class TimeParserTest extends ValueParserTestBase {
 					'+0000002000000000-00-00T00:00:00Z',
 					0, 0, 0,
 					TimeValue::PRECISION_Ga,
-					TimeParser::CALENDAR_GREGORIAN
+					$gregorian
 				),
 			),
 			'+0000020000000000-00-00T00:00:00Z' => array(
@@ -148,7 +151,7 @@ class TimeParserTest extends ValueParserTestBase {
 					'+0000020000000000-00-00T00:00:00Z',
 					0, 0, 0,
 					TimeValue::PRECISION_Ga,
-					TimeParser::CALENDAR_GREGORIAN
+					$gregorian
 				),
 			),
 			'+0000200000000000-00-00T00:00:00Z' => array(
@@ -156,7 +159,7 @@ class TimeParserTest extends ValueParserTestBase {
 					'+0000200000000000-00-00T00:00:00Z',
 					0, 0, 0,
 					TimeValue::PRECISION_Ga,
-					TimeParser::CALENDAR_GREGORIAN
+					$gregorian
 				),
 			),
 			'+0002000000000000-00-00T00:00:00Z' => array(
@@ -164,7 +167,7 @@ class TimeParserTest extends ValueParserTestBase {
 					'+0002000000000000-00-00T00:00:00Z',
 					0, 0, 0,
 					TimeValue::PRECISION_Ga,
-					TimeParser::CALENDAR_GREGORIAN
+					$gregorian
 				),
 			),
 			'+0020000000000000-00-00T00:00:00Z' => array(
@@ -172,7 +175,7 @@ class TimeParserTest extends ValueParserTestBase {
 					'+0020000000000000-00-00T00:00:00Z',
 					0, 0, 0,
 					TimeValue::PRECISION_Ga,
-					TimeParser::CALENDAR_GREGORIAN
+					$gregorian
 				),
 			),
 			'+0200000000000000-00-00T00:00:00Z' => array(
@@ -180,7 +183,7 @@ class TimeParserTest extends ValueParserTestBase {
 					'+0200000000000000-00-00T00:00:00Z',
 					0, 0, 0,
 					TimeValue::PRECISION_Ga,
-					TimeParser::CALENDAR_GREGORIAN
+					$gregorian
 				),
 			),
 			'+2000000000000000-00-00T00:00:00Z' => array(
@@ -188,7 +191,7 @@ class TimeParserTest extends ValueParserTestBase {
 					'+2000000000000000-00-00T00:00:00Z',
 					0, 0, 0,
 					TimeValue::PRECISION_Ga,
-					TimeParser::CALENDAR_GREGORIAN
+					$gregorian
 				),
 			),
 			'+0000000000002013-07-16T00:00:00Z (Gregorian)' => array(
@@ -196,7 +199,7 @@ class TimeParserTest extends ValueParserTestBase {
 					'+0000000000002013-07-16T00:00:00Z',
 					0, 0, 0,
 					TimeValue::PRECISION_DAY,
-					TimeParser::CALENDAR_GREGORIAN
+					$gregorian
 				),
 			),
 			'+0000000000000000-01-01T00:00:00Z (Gregorian)' => array(
@@ -204,7 +207,7 @@ class TimeParserTest extends ValueParserTestBase {
 					'+0000000000000000-01-01T00:00:00Z',
 					0, 0, 0,
 					TimeValue::PRECISION_DAY,
-					TimeParser::CALENDAR_GREGORIAN
+					$gregorian
 				),
 			),
 			'+0000000000000001-01-14T00:00:00Z (Julian)' => array(
@@ -212,7 +215,7 @@ class TimeParserTest extends ValueParserTestBase {
 					'+0000000000000001-01-14T00:00:00Z',
 					0, 0, 0,
 					TimeValue::PRECISION_DAY,
-					TimeParser::CALENDAR_JULIAN
+					$julian
 				),
 			),
 			'+0000000000010000-01-01T00:00:00Z (Gregorian)' => array(
@@ -220,7 +223,7 @@ class TimeParserTest extends ValueParserTestBase {
 					'+0000000000010000-01-01T00:00:00Z',
 					0, 0, 0,
 					TimeValue::PRECISION_DAY,
-					TimeParser::CALENDAR_GREGORIAN
+					$gregorian
 				),
 			),
 			'-0000000000000001-01-01T00:00:00Z (Gregorian)' => array(
@@ -228,7 +231,7 @@ class TimeParserTest extends ValueParserTestBase {
 					'-0000000000000001-01-01T00:00:00Z',
 					0, 0, 0,
 					TimeValue::PRECISION_DAY,
-					TimeParser::CALENDAR_GREGORIAN
+					$gregorian
 				),
 			),
 			'-00000000001-01-01T00:00:00Z (Gregorian)' => array(
@@ -236,7 +239,7 @@ class TimeParserTest extends ValueParserTestBase {
 					'-0000000000000001-01-01T00:00:00Z',
 					0, 0, 0,
 					TimeValue::PRECISION_DAY,
-					TimeParser::CALENDAR_GREGORIAN
+					$gregorian
 				),
 			),
 			'-000001-01-01T00:00:00Z (Gregorian)' => array(
@@ -244,7 +247,7 @@ class TimeParserTest extends ValueParserTestBase {
 					'-0000000000000001-01-01T00:00:00Z',
 					0, 0, 0,
 					TimeValue::PRECISION_DAY,
-					TimeParser::CALENDAR_GREGORIAN
+					$gregorian
 				),
 			),
 			'-1-01-01T00:00:00Z (Gregorian)' => array(
@@ -252,7 +255,7 @@ class TimeParserTest extends ValueParserTestBase {
 					'-0000000000000001-01-01T00:00:00Z',
 					0, 0, 0,
 					TimeValue::PRECISION_DAY,
-					TimeParser::CALENDAR_GREGORIAN
+					$gregorian
 				),
 			),
 
@@ -262,7 +265,7 @@ class TimeParserTest extends ValueParserTestBase {
 					'-0000000000000001-01-02T00:00:00Z',
 					0, 0, 0,
 					TimeValue::PRECISION_DAY,
-					TimeParser::CALENDAR_GREGORIAN
+					$gregorian
 				),
 				$gregorianOpts,
 			),
@@ -271,7 +274,7 @@ class TimeParserTest extends ValueParserTestBase {
 					'-0000000000000001-01-03T00:00:00Z',
 					0, 0, 0,
 					TimeValue::PRECISION_DAY,
-					TimeParser::CALENDAR_JULIAN
+					$julian
 				),
 				$julianOpts,
 			),
@@ -280,7 +283,7 @@ class TimeParserTest extends ValueParserTestBase {
 					'-0000000000000001-01-04T00:00:00Z',
 					0, 0, 0,
 					TimeValue::PRECISION_10a,
-					TimeParser::CALENDAR_GREGORIAN
+					$gregorian
 				),
 				$prec10aOpts,
 			),
@@ -289,7 +292,7 @@ class TimeParserTest extends ValueParserTestBase {
 					'-0000000000000001-01-05T00:00:00Z',
 					0, 0, 0,
 					TimeValue::PRECISION_DAY,
-					TimeParser::CALENDAR_GREGORIAN
+					$gregorian
 				),
 				$noPrecOpts,
 			),
@@ -299,7 +302,7 @@ class TimeParserTest extends ValueParserTestBase {
 					'+0000000000001999-00-00T00:00:00Z',
 					0, 0, 0,
 					TimeValue::PRECISION_YEAR,
-					TimeParser::CALENDAR_GREGORIAN
+					$gregorian
 				),
 			),
 			'+2000-00-00T00:00:00Z' => array(
@@ -307,7 +310,7 @@ class TimeParserTest extends ValueParserTestBase {
 					'+0000000000002000-00-00T00:00:00Z',
 					0, 0, 0,
 					TimeValue::PRECISION_YEAR,
-					TimeParser::CALENDAR_GREGORIAN
+					$gregorian
 				),
 			),
 			'+2010-00-00T00:00:00Z' => array(
@@ -315,7 +318,7 @@ class TimeParserTest extends ValueParserTestBase {
 					'+0000000000002010-00-00T00:00:00Z',
 					0, 0, 0,
 					TimeValue::PRECISION_YEAR,
-					TimeParser::CALENDAR_GREGORIAN
+					$gregorian
 				),
 			),
 
@@ -326,7 +329,7 @@ class TimeParserTest extends ValueParserTestBase {
 					'+0000000000000012-12-00T00:00:00Z',
 					0, 0, 0,
 					TimeValue::PRECISION_MONTH,
-					TimeParser::CALENDAR_GREGORIAN
+					$gregorian
 				),
 				$precDayOpts,
 			),
@@ -342,7 +345,7 @@ class TimeParserTest extends ValueParserTestBase {
 				// Because PHP magically turns numeric keys into ints/floats
 				(string)$key,
 				$timeValue,
-				new TimeParser( new CalendarModelParser( $options ), $options )
+				new IsoTimestampParser( new CalendarModelParser( $options ), $options )
 			);
 		}
 


### PR DESCRIPTION
Two main reasons for the rename:

1. We do have two parser with the same name `TimeParser`, which is at least confusing and will turn out do be a problem if we ever try to move both into the same component. The other `TimeParser` in lib does have it's name for a good reason: It's the generic "head" parser that does nothing but call all the other, specific parsers.
2. This parser is not a generic "time" parser, it's very specific: It can only parse strings that are (or resemble) ISO timestamps.

I suggest to call this an "ISO" parser even if we are trying to avoid the word "ISO" (see [T88438](https://phabricator.wikimedia.org/T88438) and related) because this parser can parse ISO **and** stuff that resembles but is not ISO.

Bug: [T93772](https://phabricator.wikimedia.org/T93772)