### PR TITLE
Unify names of time precision constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ DataValues Time has been written by the Wikidata team, as [Wikimedia Germany]
 ### 0.8.0 (alpha)
 
 #### Breaking changes
+* Renamed all `TimeValue::PRECISION_...` constants with lower case letters, e.g. `PRECISION_10a` to `PRECISION_YEAR10`
 * `IsoTimestampParser` auto-detects the calendar model and does not default to Gregorian any more
 * Removed `IsoTimestampParser::PRECISION_NONE`, use `null` instead
 * `TimeValue`s leap second range changed from [0..62] to [0..61]

--- a/src/DataValues/TimeValue.php
+++ b/src/DataValues/TimeValue.php
@@ -14,15 +14,15 @@ namespace DataValues;
  */
 class TimeValue extends DataValueObject {
 
-	const PRECISION_Ga = 0; // Gigayear
-	const PRECISION_100Ma = 1; // 100 Megayears
-	const PRECISION_10Ma = 2; // 10 Megayears
-	const PRECISION_Ma = 3; // Megayear
-	const PRECISION_100ka = 4; // 100 Kiloyears
-	const PRECISION_10ka = 5; // 10 Kiloyears
-	const PRECISION_ka = 6; // Kiloyear
-	const PRECISION_100a = 7; // 100 years
-	const PRECISION_10a = 8; // 10 years
+	const PRECISION_YEAR1G = 0;
+	const PRECISION_YEAR100M = 1;
+	const PRECISION_YEAR10M = 2;
+	const PRECISION_YEAR1M = 3;
+	const PRECISION_YEAR100K = 4;
+	const PRECISION_YEAR10K = 5;
+	const PRECISION_YEAR1K = 6;
+	const PRECISION_YEAR100 = 7;
+	const PRECISION_YEAR10 = 8;
 	const PRECISION_YEAR = 9;
 	const PRECISION_MONTH = 10;
 	const PRECISION_DAY = 11;
@@ -127,7 +127,7 @@ class TimeValue extends DataValueObject {
 
 		if ( !is_int( $precision ) ) {
 			throw new IllegalValueException( '$precision must be an integer' );
-		} elseif ( $precision < self::PRECISION_Ga || $precision > self::PRECISION_SECOND ) {
+		} elseif ( $precision < self::PRECISION_YEAR1G || $precision > self::PRECISION_SECOND ) {
 			throw new IllegalValueException( '$precision out of allowed bounds' );
 		}
 

--- a/src/ValueParsers/IsoTimestampParser.php
+++ b/src/ValueParsers/IsoTimestampParser.php
@@ -172,8 +172,8 @@ class IsoTimestampParser extends StringValueParser {
 
 		$rightZeros = strlen( $unsignedYear ) - strlen( rtrim( $unsignedYear, '0' ) );
 		$precision = TimeValue::PRECISION_YEAR - $rightZeros;
-		if ( $precision < TimeValue::PRECISION_Ga ) {
-			$precision = TimeValue::PRECISION_Ga;
+		if ( $precision < TimeValue::PRECISION_YEAR1G ) {
+			$precision = TimeValue::PRECISION_YEAR1G;
 		}
 
 		return $precision;

--- a/tests/DataValues/TimeValueCalculatorTest.php
+++ b/tests/DataValues/TimeValueCalculatorTest.php
@@ -207,8 +207,8 @@ class TimeValueCalculatorTest extends \PHPUnit_Framework_TestCase {
 			array( TimeValue::PRECISION_DAY, $secondsPerDay ),
 			array( TimeValue::PRECISION_MONTH, $secondsPerDay * $daysPerGregorianYear / 12 ),
 			array( TimeValue::PRECISION_YEAR, $secondsPerDay * $daysPerGregorianYear ),
-			array( TimeValue::PRECISION_10a, $secondsPerDay * $daysPerGregorianYear * 1e1 ),
-			array( TimeValue::PRECISION_Ga, $secondsPerDay * $daysPerGregorianYear * 1e9 ),
+			array( TimeValue::PRECISION_YEAR10, $secondsPerDay * $daysPerGregorianYear * 1e1 ),
+			array( TimeValue::PRECISION_YEAR1G, $secondsPerDay * $daysPerGregorianYear * 1e9 ),
 		);
 	}
 

--- a/tests/DataValues/TimeValueTest.php
+++ b/tests/DataValues/TimeValueTest.php
@@ -39,7 +39,7 @@ class TimeValueTest extends DataValueTest {
 			'Maximum timezone' => array(
 				'+2013-01-01T00:00:00Z',
 				7200, 9001, 9001,
-				TimeValue::PRECISION_Ga,
+				TimeValue::PRECISION_YEAR1G,
 				'http://nyan.cat/original.php'
 			),
 			'Minimum timezone' => array(

--- a/tests/ValueFormatters/TimeFormatterTest.php
+++ b/tests/ValueFormatters/TimeFormatterTest.php
@@ -71,7 +71,7 @@ class TimeFormatterTest extends ValueFormatterTestBase {
 			),
 			'+2013-07-19T00:00:00Z' => array(
 				'+00000002013-07-19T00:00:00Z',
-				TimeValue::PRECISION_10a,
+				TimeValue::PRECISION_YEAR10,
 			),
 		);
 

--- a/tests/ValueParsers/IsoTimestampParserTest.php
+++ b/tests/ValueParsers/IsoTimestampParserTest.php
@@ -48,7 +48,7 @@ class IsoTimestampParserTest extends ValueParserTestBase {
 		$gregorianOpts->setOption( IsoTimestampParser::OPT_CALENDAR, $gregorian );
 
 		$prec10aOpts = new ParserOptions();
-		$prec10aOpts->setOption( IsoTimestampParser::OPT_PRECISION, TimeValue::PRECISION_10a );
+		$prec10aOpts->setOption( IsoTimestampParser::OPT_PRECISION, TimeValue::PRECISION_YEAR10 );
 
 		$precDayOpts = new ParserOptions();
 		$precDayOpts->setOption( IsoTimestampParser::OPT_PRECISION, TimeValue::PRECISION_DAY );
@@ -81,59 +81,59 @@ class IsoTimestampParserTest extends ValueParserTestBase {
 			),
 			'+0000000000008000-00-00T00:00:00Z' => array(
 				'+8000-00-00T00:00:00Z',
-				TimeValue::PRECISION_ka,
+				TimeValue::PRECISION_YEAR1K,
 			),
 			'+0000000000020000-00-00T00:00:00Z' => array(
 				'+20000-00-00T00:00:00Z',
-				TimeValue::PRECISION_10ka,
+				TimeValue::PRECISION_YEAR10K,
 			),
 			'+0000000000200000-00-00T00:00:00Z' => array(
 				'+200000-00-00T00:00:00Z',
-				TimeValue::PRECISION_100ka,
+				TimeValue::PRECISION_YEAR100K,
 			),
 			'+0000000002000000-00-00T00:00:00Z' => array(
 				'+2000000-00-00T00:00:00Z',
-				TimeValue::PRECISION_Ma,
+				TimeValue::PRECISION_YEAR1M,
 			),
 			'+0000000020000000-00-00T00:00:00Z' => array(
 				'+20000000-00-00T00:00:00Z',
-				TimeValue::PRECISION_10Ma,
+				TimeValue::PRECISION_YEAR10M,
 			),
 			'+0000000200000000-00-00T00:00:00Z' => array(
 				'+200000000-00-00T00:00:00Z',
-				TimeValue::PRECISION_100Ma,
+				TimeValue::PRECISION_YEAR100M,
 			),
 			'+0000002000000000-00-00T00:00:00Z' => array(
 				'+2000000000-00-00T00:00:00Z',
-				TimeValue::PRECISION_Ga,
+				TimeValue::PRECISION_YEAR1G,
 			),
 			'+0000020000000000-00-00T00:00:00Z' => array(
 				'+20000000000-00-00T00:00:00Z',
-				TimeValue::PRECISION_Ga,
+				TimeValue::PRECISION_YEAR1G,
 			),
 			'+0000200000000000-00-00T00:00:00Z' => array(
 				'+200000000000-00-00T00:00:00Z',
-				TimeValue::PRECISION_Ga,
+				TimeValue::PRECISION_YEAR1G,
 			),
 			'+0002000000000000-00-00T00:00:00Z' => array(
 				'+2000000000000-00-00T00:00:00Z',
-				TimeValue::PRECISION_Ga,
+				TimeValue::PRECISION_YEAR1G,
 			),
 			'+0020000000000000-00-00T00:00:00Z' => array(
 				'+20000000000000-00-00T00:00:00Z',
-				TimeValue::PRECISION_Ga,
+				TimeValue::PRECISION_YEAR1G,
 			),
 			'+0200000000000000-00-00T00:00:00Z' => array(
 				'+200000000000000-00-00T00:00:00Z',
-				TimeValue::PRECISION_Ga,
+				TimeValue::PRECISION_YEAR1G,
 			),
 			'+2000000000000000-00-00T00:00:00Z' => array(
 				'+2000000000000000-00-00T00:00:00Z',
-				TimeValue::PRECISION_Ga,
+				TimeValue::PRECISION_YEAR1G,
 			),
 			'-2000000000000000-00-00T00:00:00Z' => array(
 				'-2000000000000000-00-00T00:00:00Z',
-				TimeValue::PRECISION_Ga,
+				TimeValue::PRECISION_YEAR1G,
 				$julian
 			),
 			'+0000000000002013-07-16T00:00:00Z (Gregorian)' => array(
@@ -197,7 +197,7 @@ class IsoTimestampParserTest extends ValueParserTestBase {
 			),
 			'-1-01-04T00:00:00Z' => array(
 				'-0001-01-04T00:00:00Z',
-				TimeValue::PRECISION_10a,
+				TimeValue::PRECISION_YEAR10,
 				$julian,
 				$prec10aOpts,
 			),


### PR DESCRIPTION
Also see:
* https://github.com/wmde/DataValuesJavascript/pull/68
* https://gerrit.wikimedia.org/r/#/c/194306/

[Bug: T99911](https://phabricator.wikimedia.org/T99911)