### PR TITLE
Simplify options handling

### DIFF
--- a/src/ValueParsers/TimeParser.php
+++ b/src/ValueParsers/TimeParser.php
@@ -39,16 +39,16 @@ class TimeParser extends StringValueParser {
 	/**
 	 * @since 0.1
 	 *
-	 * @param CalendarModelParser $calendarModelParser
+	 * @param CalendarModelParser|null $calendarModelParser
 	 * @param ParserOptions|null $options
 	 */
-	public function __construct( CalendarModelParser $calendarModelParser, ParserOptions $options = null ) {
-
-		$options->defaultOption( TimeParser::OPT_CALENDAR, TimeParser::CALENDAR_GREGORIAN );
-		$options->defaultOption( TimeParser::OPT_PRECISION, TimeParser::PRECISION_NONE );
-
+	public function __construct( CalendarModelParser $calendarModelParser = null, ParserOptions $options = null ) {
 		parent::__construct( $options );
-		$this->calendarModelParser = $calendarModelParser;
+
+		$this->defaultOption( TimeParser::OPT_CALENDAR, TimeParser::CALENDAR_GREGORIAN );
+		$this->defaultOption( TimeParser::OPT_PRECISION, TimeParser::PRECISION_NONE );
+
+		$this->calendarModelParser = $calendarModelParser ?: new CalendarModelParser();
 	}
 
 	protected function stringParse( $value ) {

--- a/tests/ValueParsers/TimeParserTest.php
+++ b/tests/ValueParsers/TimeParserTest.php
@@ -28,39 +28,31 @@ class TimeParserTest extends ValueParserTestBase {
 	}
 
 	/**
-	 * @since 0.1
 	 * @return TimeParser
 	 */
 	protected function getInstance() {
-		$options = $this->newParserOptions();
-
-		$class = $this->getParserClass();
-		return new $class( new CalendarModelParser(), $options );
+		return new TimeParser();
 	}
 
 	/**
 	 * @see ValueParserTestBase::validInputProvider
-	 *
-	 * @since 0.1
-	 *
-	 * @return array
 	 */
 	public function validInputProvider() {
 		$emptyOpts = new ParserOptions();
 
-		$julianOpts = clone $emptyOpts;
+		$julianOpts = new ParserOptions();
 		$julianOpts->setOption( TimeParser::OPT_CALENDAR, TimeParser::CALENDAR_JULIAN );
 
-		$gregorianOpts = clone $emptyOpts;
+		$gregorianOpts = new ParserOptions();
 		$gregorianOpts->setOption( TimeParser::OPT_CALENDAR, TimeParser::CALENDAR_GREGORIAN );
 
-		$prec10aOpts = clone $emptyOpts;
+		$prec10aOpts = new ParserOptions();
 		$prec10aOpts->setOption( TimeParser::OPT_PRECISION, TimeValue::PRECISION_10a );
 
-		$precDayOpts = clone $emptyOpts;
+		$precDayOpts = new ParserOptions();
 		$precDayOpts->setOption( TimeParser::OPT_PRECISION, TimeValue::PRECISION_DAY );
 
-		$noPrecOpts = clone $emptyOpts;
+		$noPrecOpts = new ParserOptions();
 		$noPrecOpts->setOption( TimeParser::OPT_PRECISION, TimeParser::PRECISION_NONE );
 
 		$valid = array(


### PR DESCRIPTION
This removes quite some obsolete code.

Originally the goal was to remove the unused newParserOptions method and to simplify the getInstance methods as much as possible. The additional changes are very closely related.