### PR TITLE
Deprecate getParserClass in favor of getInstance

### DIFF
--- a/tests/ValueParsers/CalendarModelParserTest.php
+++ b/tests/ValueParsers/CalendarModelParserTest.php
@@ -3,6 +3,7 @@
 namespace ValueParsers\Test;
 
 use ValueFormatters\TimeFormatter;
+use ValueParsers\CalendarModelParser;
 
 /**
  * @covers \ValueParsers\CalendarModelParser
@@ -14,8 +15,20 @@ use ValueFormatters\TimeFormatter;
  */
 class CalendarModelParserTest extends ValueParserTestBase {
 
+	/**
+	 * @deprecated since 0.3, just use getInstance.
+	 */
 	protected function getParserClass() {
 		return 'ValueParsers\CalendarModelParser';
+	}
+
+	/**
+	 * @see ValueParserTestBase::getInstance
+	 *
+	 * @return CalendarModelParser
+	 */
+	protected function getInstance() {
+		return new CalendarModelParser();
 	}
 
 	protected function requireDataValue() {
@@ -37,4 +50,5 @@ class CalendarModelParserTest extends ValueParserTestBase {
 			array( 'foobar' ),
 		);
 	}
+
 }

--- a/tests/ValueParsers/TimeParserTest.php
+++ b/tests/ValueParsers/TimeParserTest.php
@@ -19,15 +19,15 @@ use ValueParsers\TimeParser;
 class TimeParserTest extends ValueParserTestBase {
 
 	/**
-	 * @see ValueParserTestBase::getParserClass
-	 * @since 0.1
-	 * @return string
+	 * @deprecated since 0.3, just use getInstance.
 	 */
 	protected function getParserClass() {
 		return 'ValueParsers\TimeParser';
 	}
 
 	/**
+	 * @see ValueParserTestBase::getInstance
+	 *
 	 * @return TimeParser
 	 */
 	protected function getInstance() {


### PR DESCRIPTION
See https://github.com/DataValues/Common/pull/23.

This requires #43 to be merged first, therefor the failing tests.

Bug: [T92268](https://phabricator.wikimedia.org/T92268)