### PR TITLE
Deprecate getFormatterClass in favor of getInstance

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 	"require": {
 		"php": ">=5.3.0",
 		"data-values/data-values": "~1.0|~0.1",
-		"data-values/interfaces": "~0.1.4",
+		"data-values/interfaces": "^0.1.5",
 		"data-values/common": "~0.2.0"
 	},
 	"autoload": {


### PR DESCRIPTION
Requires https://github.com/DataValues/Interfaces/pull/9 to be released as a new version.

Bug: [T92268](https://phabricator.wikimedia.org/T92268)
Bug: [T92280](https://phabricator.wikimedia.org/T92280)