### PR TITLE
Add more cases to the CalendarModelParser

### DIFF
--- a/src/ValueParsers/CalendarModelParser.php
+++ b/src/ValueParsers/CalendarModelParser.php
@@ -18,27 +18,72 @@ class CalendarModelParser extends StringValueParser {
 	const FORMAT_NAME = 'calendar-model';
 
 	/**
+	 * Option to provide localized calendar model names for unlocalization. Must be an array mapping
+	 * localized calendar model names to URIs.
+	 *
+	 * @see TimeFormatter::OPT_CALENDARNAMES
+	 */
+	const OPT_CALENDAR_MODEL_URIS = 'calendar-model-uris';
+
+	/**
+	 * @deprecated Do not use.
+	 *
 	 * Regex pattern constant matching the parable calendar models
 	 * should be used as an insensitive to match all cases
 	 *
-	 * TODO: How important is it that this regex is in sync with the list below?
+	 * TODO: How crucial is it that this regex is in sync with the list below?
 	 */
 	const MODEL_PATTERN = '(Gregorian|Julian|)';
 
-	protected function stringParse( $value ) {
-		$key = trim( $value );
+	/**
+	 * @param ParserOptions|null $options
+	 */
+	public function __construct( ParserOptions $options = null ) {
+		parent::__construct( $options );
 
-		// TODO: What about abbreviation, e.g. "greg" and "jul"?
-		// TODO: What about localizations?
-		if ( $key === ''
-			|| $key === TimeFormatter::CALENDAR_GREGORIAN
-			|| strtolower( $key ) === 'gregorian'
-		) {
-			return TimeFormatter::CALENDAR_GREGORIAN;
-		} elseif ( $key === TimeFormatter::CALENDAR_JULIAN
-			|| strtolower( $key ) === 'julian'
-		) {
-			return TimeFormatter::CALENDAR_JULIAN;
+		$this->defaultOption( self::OPT_CALENDAR_MODEL_URIS, array() );
+	}
+
+	/**
+	 * @param string $value
+	 *
+	 * @throws ParseException
+	 * @return string
+	 */
+	protected function stringParse( $value ) {
+		$uris = $this->getOption( self::OPT_CALENDAR_MODEL_URIS );
+		if ( array_key_exists( $value, $uris ) ) {
+			return $uris[$value];
+		}
+
+		switch ( $value ) {
+			case TimeFormatter::CALENDAR_GREGORIAN:
+				return TimeFormatter::CALENDAR_GREGORIAN;
+			case TimeFormatter::CALENDAR_JULIAN:
+				return TimeFormatter::CALENDAR_JULIAN;
+		}
+
+		return $this->getCalendarModelUriFromKey( $value );
+	}
+
+	/**
+	 * @param string $value
+	 *
+	 * @throws ParseException
+	 * @return string|null
+	 */
+	private function getCalendarModelUriFromKey( $value ) {
+		$key = strtolower( trim( $value ) );
+
+		// TODO: What about abbreviations, e.g. "greg"?
+		switch ( $key ) {
+			case '':
+			case 'gregorian':
+			case 'western':
+			case 'christian':
+				return TimeFormatter::CALENDAR_GREGORIAN;
+			case 'julian':
+				return TimeFormatter::CALENDAR_JULIAN;
 		}
 
 		throw new ParseException( 'Cannot parse calendar model', $value, self::FORMAT_NAME );

--- a/src/ValueParsers/CalendarModelParser.php
+++ b/src/ValueParsers/CalendarModelParser.php
@@ -11,6 +11,7 @@ use ValueFormatters\TimeFormatter;
  *
  * @licence GNU GPL v2+
  * @author Adam Shorland
+ * @author Thiemo Mättig
  */
 class CalendarModelParser extends StringValueParser {
 
@@ -19,22 +20,28 @@ class CalendarModelParser extends StringValueParser {
 	/**
 	 * Regex pattern constant matching the parable calendar models
 	 * should be used as an insensitive to match all cases
+	 *
+	 * TODO: How important is it that this regex is in sync with the list below?
 	 */
 	const MODEL_PATTERN = '(Gregorian|Julian|)';
 
 	protected function stringParse( $value ) {
-		$rawValue = $value;
+		$key = trim( $value );
 
-		$value = strtolower( $value );
-
-		switch ( $value ) {
-			case '':
-			case 'gregorian':
-				return TimeFormatter::CALENDAR_GREGORIAN;
-			case 'julian':
-				return TimeFormatter::CALENDAR_JULIAN;
+		// TODO: What about abbreviation, e.g. "greg" and "jul"?
+		// TODO: What about localizations?
+		if ( $key === ''
+			|| $key === TimeFormatter::CALENDAR_GREGORIAN
+			|| strtolower( $key ) === 'gregorian'
+		) {
+			return TimeFormatter::CALENDAR_GREGORIAN;
+		} elseif ( $key === TimeFormatter::CALENDAR_JULIAN
+			|| strtolower( $key ) === 'julian'
+		) {
+			return TimeFormatter::CALENDAR_JULIAN;
 		}
 
-		throw new ParseException( 'Cannot parse calendar model', $rawValue, self::FORMAT_NAME );
+		throw new ParseException( 'Cannot parse calendar model', $value, self::FORMAT_NAME );
 	}
+
 }

--- a/tests/ValueParsers/CalendarModelParserTest.php
+++ b/tests/ValueParsers/CalendarModelParserTest.php
@@ -31,22 +31,42 @@ class CalendarModelParserTest extends ValueParserTestBase {
 		return new CalendarModelParser();
 	}
 
+	/**
+	 * @see ValueParserTestBase::requireDataValue
+	 *
+	 * @return bool
+	 */
 	protected function requireDataValue() {
 		return false;
 	}
 
+	/**
+	 * @see ValueParserTestBase::validInputProvider
+	 */
 	public function validInputProvider() {
 		return array(
 			array( '', TimeFormatter::CALENDAR_GREGORIAN ),
+			array( ' ', TimeFormatter::CALENDAR_GREGORIAN ),
 			array( 'Gregorian', TimeFormatter::CALENDAR_GREGORIAN ),
 			array( 'GreGOrIAN', TimeFormatter::CALENDAR_GREGORIAN ),
+			array( ' Gregorian ', TimeFormatter::CALENDAR_GREGORIAN ),
+			array( TimeFormatter::CALENDAR_GREGORIAN, TimeFormatter::CALENDAR_GREGORIAN ),
+
 			array( 'julian', TimeFormatter::CALENDAR_JULIAN ),
 			array( 'JULIAN', TimeFormatter::CALENDAR_JULIAN ),
+			array( ' Julian ', TimeFormatter::CALENDAR_JULIAN ),
+			array( TimeFormatter::CALENDAR_JULIAN, TimeFormatter::CALENDAR_JULIAN ),
 		);
 	}
 
+	/**
+	 * @see ValueParserTestBase::invalidInputProvider
+	 */
 	public function invalidInputProvider() {
 		return array(
+			array( null ),
+			array( true ),
+			array( 1 ),
 			array( 'foobar' ),
 		);
 	}

--- a/tests/ValueParsers/CalendarModelParserTest.php
+++ b/tests/ValueParsers/CalendarModelParserTest.php
@@ -4,6 +4,7 @@ namespace ValueParsers\Test;
 
 use ValueFormatters\TimeFormatter;
 use ValueParsers\CalendarModelParser;
+use ValueParsers\ParserOptions;
 
 /**
  * @covers \ValueParsers\CalendarModelParser
@@ -12,6 +13,7 @@ use ValueParsers\CalendarModelParser;
  * @group DataValueExtensions
  *
  * @author Adam Shorland
+ * @author Thiemo Mättig
  */
 class CalendarModelParserTest extends ValueParserTestBase {
 
@@ -19,7 +21,7 @@ class CalendarModelParserTest extends ValueParserTestBase {
 	 * @deprecated since 0.3, just use getInstance.
 	 */
 	protected function getParserClass() {
-		return 'ValueParsers\CalendarModelParser';
+		throw new \LogicException( 'Should not be called, use getInstance' );
 	}
 
 	/**
@@ -28,7 +30,13 @@ class CalendarModelParserTest extends ValueParserTestBase {
 	 * @return CalendarModelParser
 	 */
 	protected function getInstance() {
-		return new CalendarModelParser();
+		$options = new ParserOptions();
+
+		$options->setOption( CalendarModelParser::OPT_CALENDAR_MODEL_URIS, array(
+			'Localized' => 'Unlocalized',
+		) );
+
+		return new CalendarModelParser( $options );
 	}
 
 	/**
@@ -46,16 +54,29 @@ class CalendarModelParserTest extends ValueParserTestBase {
 	public function validInputProvider() {
 		return array(
 			array( '', TimeFormatter::CALENDAR_GREGORIAN ),
-			array( ' ', TimeFormatter::CALENDAR_GREGORIAN ),
 			array( 'Gregorian', TimeFormatter::CALENDAR_GREGORIAN ),
-			array( 'GreGOrIAN', TimeFormatter::CALENDAR_GREGORIAN ),
-			array( ' Gregorian ', TimeFormatter::CALENDAR_GREGORIAN ),
-			array( TimeFormatter::CALENDAR_GREGORIAN, TimeFormatter::CALENDAR_GREGORIAN ),
+			array( 'Julian', TimeFormatter::CALENDAR_JULIAN ),
 
+			// White space
+			array( ' ', TimeFormatter::CALENDAR_GREGORIAN ),
+			array( ' Gregorian ', TimeFormatter::CALENDAR_GREGORIAN ),
+			array( ' Julian ', TimeFormatter::CALENDAR_JULIAN ),
+
+			// Capitalization
+			array( 'GreGOrIAN', TimeFormatter::CALENDAR_GREGORIAN ),
 			array( 'julian', TimeFormatter::CALENDAR_JULIAN ),
 			array( 'JULIAN', TimeFormatter::CALENDAR_JULIAN ),
-			array( ' Julian ', TimeFormatter::CALENDAR_JULIAN ),
-			array( TimeFormatter::CALENDAR_JULIAN, TimeFormatter::CALENDAR_JULIAN ),
+
+			// See https://en.wikipedia.org/wiki/Gregorian_calendar
+			array( 'Western', TimeFormatter::CALENDAR_GREGORIAN ),
+			array( 'Christian', TimeFormatter::CALENDAR_GREGORIAN ),
+
+			// URIs
+			array( 'http://www.wikidata.org/entity/Q1985727', TimeFormatter::CALENDAR_GREGORIAN ),
+			array( 'http://www.wikidata.org/entity/Q1985786', TimeFormatter::CALENDAR_JULIAN ),
+
+			// Via OPT_CALENDAR_MODEL_URIS
+			array( 'Localized', 'Unlocalized' ),
 		);
 	}
 
@@ -68,6 +89,20 @@ class CalendarModelParserTest extends ValueParserTestBase {
 			array( true ),
 			array( 1 ),
 			array( 'foobar' ),
+
+			// Do not confuse Greece with Gregorian
+			array( 'gr' ),
+			array( 'gre' ),
+
+			// Do not confuse July with Julian
+			array( 'Jul' ),
+			array( 'J' ),
+
+			// Strict comparison for URIs and strings given via OPT_CALENDAR_MODEL_URIS
+			array( 'http://www.wikidata.org/entity/Q1985727 ' ),
+			array( 'Localized ' ),
+			array( 'localized' ),
+			array( 'LOCALIZED' ),
 		);
 	}
 


### PR DESCRIPTION
* Trim before comparing. This is what almost all our parsers do.
* Add support for the actual URIs. If they don't identify the calendar model, I don't know. ;-)