### PR TITLE
Simplify TimeParserTest

### DIFF
--- a/tests/ValueParsers/TimeParserTest.php
+++ b/tests/ValueParsers/TimeParserTest.php
@@ -3,7 +3,6 @@
 namespace ValueParsers\Test;
 
 use DataValues\TimeValue;
-use ValueFormatters\TimeFormatter;
 use ValueParsers\CalendarModelParser;
 use ValueParsers\ParserOptions;
 use ValueParsers\TimeParser;
@@ -38,8 +37,6 @@ class TimeParserTest extends ValueParserTestBase {
 	 * @see ValueParserTestBase::validInputProvider
 	 */
 	public function validInputProvider() {
-		$emptyOpts = new ParserOptions();
-
 		$julianOpts = new ParserOptions();
 		$julianOpts->setOption( TimeParser::OPT_CALENDAR, TimeParser::CALENDAR_JULIAN );
 
@@ -58,372 +55,278 @@ class TimeParserTest extends ValueParserTestBase {
 		$valid = array(
 			// Empty options tests
 			'+0000000000002013-07-16T00:00:00Z' => array(
-				TimeValue::newFromArray( array(
-					'time' => '+0000000000002013-07-16T00:00:00Z',
-					'timezone' => 0,
-					'before' => 0,
-					'after' => 0,
-					'precision' => TimeValue::PRECISION_DAY,
-					'calendarmodel' => TimeFormatter::CALENDAR_GREGORIAN
-				) ),
-				$emptyOpts,
+				new TimeValue(
+					'+0000000000002013-07-16T00:00:00Z',
+					0, 0, 0,
+					TimeValue::PRECISION_DAY,
+					TimeParser::CALENDAR_GREGORIAN
+				),
 			),
 			'+0000000000002013-07-00T00:00:00Z' => array(
-				TimeValue::newFromArray( array(
-					'time' => '+0000000000002013-07-00T00:00:00Z',
-					'timezone' => 0,
-					'before' => 0,
-					'after' => 0,
-					'precision' => TimeValue::PRECISION_MONTH,
-					'calendarmodel' => TimeFormatter::CALENDAR_GREGORIAN
-				) ),
-				$emptyOpts,
+				new TimeValue(
+					'+0000000000002013-07-00T00:00:00Z',
+					0, 0, 0,
+					TimeValue::PRECISION_MONTH,
+					TimeParser::CALENDAR_GREGORIAN
+				),
 			),
 			'+0000000000002013-00-00T00:00:00Z' => array(
-				TimeValue::newFromArray( array(
-					'time' => '+0000000000002013-00-00T00:00:00Z',
-					'timezone' => 0,
-					'before' => 0,
-					'after' => 0,
-					'precision' => TimeValue::PRECISION_YEAR,
-					'calendarmodel' => TimeFormatter::CALENDAR_GREGORIAN
-				) ),
-				$emptyOpts,
+				new TimeValue(
+					'+0000000000002013-00-00T00:00:00Z',
+					0, 0, 0,
+					TimeValue::PRECISION_YEAR,
+					TimeParser::CALENDAR_GREGORIAN
+				),
 			),
 			'+0000000000002000-00-00T00:00:00Z' => array(
-				TimeValue::newFromArray( array(
-					'time' => '+0000000000002000-00-00T00:00:00Z',
-					'timezone' => 0,
-					'before' => 0,
-					'after' => 0,
-					'precision' => TimeValue::PRECISION_YEAR,
-					'calendarmodel' => TimeFormatter::CALENDAR_GREGORIAN
-				) ),
-				$emptyOpts,
+				new TimeValue(
+					'+0000000000002000-00-00T00:00:00Z',
+					0, 0, 0,
+					TimeValue::PRECISION_YEAR,
+					TimeParser::CALENDAR_GREGORIAN
+				),
 			),
 			'+0000000000008000-00-00T00:00:00Z' => array(
-				TimeValue::newFromArray( array(
-					'time' => '+0000000000008000-00-00T00:00:00Z',
-					'timezone' => 0,
-					'before' => 0,
-					'after' => 0,
-					'precision' => TimeValue::PRECISION_ka,
-					'calendarmodel' => TimeFormatter::CALENDAR_GREGORIAN
-				) ),
-				$emptyOpts,
+				new TimeValue(
+					'+0000000000008000-00-00T00:00:00Z',
+					0, 0, 0,
+					TimeValue::PRECISION_ka,
+					TimeParser::CALENDAR_GREGORIAN
+				),
 			),
 			'+0000000000020000-00-00T00:00:00Z' => array(
-				TimeValue::newFromArray( array(
-					'time' => '+0000000000020000-00-00T00:00:00Z',
-					'timezone' => 0,
-					'before' => 0,
-					'after' => 0,
-					'precision' => TimeValue::PRECISION_10ka,
-					'calendarmodel' => TimeFormatter::CALENDAR_GREGORIAN
-				) ),
-				$emptyOpts,
+				new TimeValue(
+					'+0000000000020000-00-00T00:00:00Z',
+					0, 0, 0,
+					TimeValue::PRECISION_10ka,
+					TimeParser::CALENDAR_GREGORIAN
+				),
 			),
 			'+0000000000200000-00-00T00:00:00Z' => array(
-				TimeValue::newFromArray( array(
-					'time' => '+0000000000200000-00-00T00:00:00Z',
-					'timezone' => 0,
-					'before' => 0,
-					'after' => 0,
-					'precision' => TimeValue::PRECISION_100ka,
-					'calendarmodel' => TimeFormatter::CALENDAR_GREGORIAN
-				) ),
-				$emptyOpts,
+				new TimeValue(
+					'+0000000000200000-00-00T00:00:00Z',
+					0, 0, 0,
+					TimeValue::PRECISION_100ka,
+					TimeParser::CALENDAR_GREGORIAN
+				),
 			),
 			'+0000000002000000-00-00T00:00:00Z' => array(
-				TimeValue::newFromArray( array(
-					'time' => '+0000000002000000-00-00T00:00:00Z',
-					'timezone' => 0,
-					'before' => 0,
-					'after' => 0,
-					'precision' => TimeValue::PRECISION_Ma,
-					'calendarmodel' => TimeFormatter::CALENDAR_GREGORIAN
-				) ),
-				$emptyOpts,
+				new TimeValue(
+					'+0000000002000000-00-00T00:00:00Z',
+					0, 0, 0,
+					TimeValue::PRECISION_Ma,
+					TimeParser::CALENDAR_GREGORIAN
+				),
 			),
 			'+0000000020000000-00-00T00:00:00Z' => array(
-				TimeValue::newFromArray( array(
-					'time' => '+0000000020000000-00-00T00:00:00Z',
-					'timezone' => 0,
-					'before' => 0,
-					'after' => 0,
-					'precision' => TimeValue::PRECISION_10Ma,
-					'calendarmodel' => TimeFormatter::CALENDAR_GREGORIAN
-				) ),
-				$emptyOpts,
+				new TimeValue(
+					'+0000000020000000-00-00T00:00:00Z',
+					0, 0, 0,
+					TimeValue::PRECISION_10Ma,
+					TimeParser::CALENDAR_GREGORIAN
+				),
 			),
 			'+0000000200000000-00-00T00:00:00Z' => array(
-				TimeValue::newFromArray( array(
-					'time' => '+0000000200000000-00-00T00:00:00Z',
-					'timezone' => 0,
-					'before' => 0,
-					'after' => 0,
-					'precision' => TimeValue::PRECISION_100Ma,
-					'calendarmodel' => TimeFormatter::CALENDAR_GREGORIAN
-				) ),
-				$emptyOpts,
+				new TimeValue(
+					'+0000000200000000-00-00T00:00:00Z',
+					0, 0, 0,
+					TimeValue::PRECISION_100Ma,
+					TimeParser::CALENDAR_GREGORIAN
+				),
 			),
 			'+0000002000000000-00-00T00:00:00Z' => array(
-				TimeValue::newFromArray( array(
-					'time' => '+0000002000000000-00-00T00:00:00Z',
-					'timezone' => 0,
-					'before' => 0,
-					'after' => 0,
-					'precision' => TimeValue::PRECISION_Ga,
-					'calendarmodel' => TimeFormatter::CALENDAR_GREGORIAN
-				) ),
-				$emptyOpts,
+				new TimeValue(
+					'+0000002000000000-00-00T00:00:00Z',
+					0, 0, 0,
+					TimeValue::PRECISION_Ga,
+					TimeParser::CALENDAR_GREGORIAN
+				),
 			),
 			'+0000020000000000-00-00T00:00:00Z' => array(
-				TimeValue::newFromArray( array(
-					'time' => '+0000020000000000-00-00T00:00:00Z',
-					'timezone' => 0,
-					'before' => 0,
-					'after' => 0,
-					'precision' => TimeValue::PRECISION_Ga,
-					'calendarmodel' => TimeFormatter::CALENDAR_GREGORIAN
-				) ),
-				$emptyOpts,
+				new TimeValue(
+					'+0000020000000000-00-00T00:00:00Z',
+					0, 0, 0,
+					TimeValue::PRECISION_Ga,
+					TimeParser::CALENDAR_GREGORIAN
+				),
 			),
 			'+0000200000000000-00-00T00:00:00Z' => array(
-				TimeValue::newFromArray( array(
-					'time' => '+0000200000000000-00-00T00:00:00Z',
-					'timezone' => 0,
-					'before' => 0,
-					'after' => 0,
-					'precision' => TimeValue::PRECISION_Ga,
-					'calendarmodel' => TimeFormatter::CALENDAR_GREGORIAN
-				) ),
-				$emptyOpts,
+				new TimeValue(
+					'+0000200000000000-00-00T00:00:00Z',
+					0, 0, 0,
+					TimeValue::PRECISION_Ga,
+					TimeParser::CALENDAR_GREGORIAN
+				),
 			),
 			'+0002000000000000-00-00T00:00:00Z' => array(
-				TimeValue::newFromArray( array(
-					'time' => '+0002000000000000-00-00T00:00:00Z',
-					'timezone' => 0,
-					'before' => 0,
-					'after' => 0,
-					'precision' => TimeValue::PRECISION_Ga,
-					'calendarmodel' => TimeFormatter::CALENDAR_GREGORIAN
-				) ),
-				$emptyOpts,
+				new TimeValue(
+					'+0002000000000000-00-00T00:00:00Z',
+					0, 0, 0,
+					TimeValue::PRECISION_Ga,
+					TimeParser::CALENDAR_GREGORIAN
+				),
 			),
 			'+0020000000000000-00-00T00:00:00Z' => array(
-				TimeValue::newFromArray( array(
-					'time' => '+0020000000000000-00-00T00:00:00Z',
-					'timezone' => 0,
-					'before' => 0,
-					'after' => 0,
-					'precision' => TimeValue::PRECISION_Ga,
-					'calendarmodel' => TimeFormatter::CALENDAR_GREGORIAN
-				) ),
-				$emptyOpts,
+				new TimeValue(
+					'+0020000000000000-00-00T00:00:00Z',
+					0, 0, 0,
+					TimeValue::PRECISION_Ga,
+					TimeParser::CALENDAR_GREGORIAN
+				),
 			),
 			'+0200000000000000-00-00T00:00:00Z' => array(
-				TimeValue::newFromArray( array(
-					'time' => '+0200000000000000-00-00T00:00:00Z',
-					'timezone' => 0,
-					'before' => 0,
-					'after' => 0,
-					'precision' => TimeValue::PRECISION_Ga,
-					'calendarmodel' => TimeFormatter::CALENDAR_GREGORIAN
-				) ),
-				$emptyOpts,
+				new TimeValue(
+					'+0200000000000000-00-00T00:00:00Z',
+					0, 0, 0,
+					TimeValue::PRECISION_Ga,
+					TimeParser::CALENDAR_GREGORIAN
+				),
 			),
 			'+2000000000000000-00-00T00:00:00Z' => array(
-				TimeValue::newFromArray( array(
-					'time' => '+2000000000000000-00-00T00:00:00Z',
-					'timezone' => 0,
-					'before' => 0,
-					'after' => 0,
-					'precision' => TimeValue::PRECISION_Ga,
-					'calendarmodel' => TimeFormatter::CALENDAR_GREGORIAN
-				) ),
-				$emptyOpts,
+				new TimeValue(
+					'+2000000000000000-00-00T00:00:00Z',
+					0, 0, 0,
+					TimeValue::PRECISION_Ga,
+					TimeParser::CALENDAR_GREGORIAN
+				),
 			),
 			'+0000000000002013-07-16T00:00:00Z (Gregorian)' => array(
-				TimeValue::newFromArray( array(
-					'time' => '+0000000000002013-07-16T00:00:00Z',
-					'timezone' => 0,
-					'before' => 0,
-					'after' => 0,
-					'precision' => TimeValue::PRECISION_DAY,
-					'calendarmodel' => TimeFormatter::CALENDAR_GREGORIAN
-			) ),
-				$emptyOpts,
+				new TimeValue(
+					'+0000000000002013-07-16T00:00:00Z',
+					0, 0, 0,
+					TimeValue::PRECISION_DAY,
+					TimeParser::CALENDAR_GREGORIAN
+				),
 			),
 			'+0000000000000000-01-01T00:00:00Z (Gregorian)' => array(
-				TimeValue::newFromArray( array(
-					'time' => '+0000000000000000-01-01T00:00:00Z',
-					'timezone' => 0,
-					'before' => 0,
-					'after' => 0,
-					'precision' => TimeValue::PRECISION_DAY,
-					'calendarmodel' => TimeFormatter::CALENDAR_GREGORIAN
-			) ),
-				$emptyOpts,
+				new TimeValue(
+					'+0000000000000000-01-01T00:00:00Z',
+					0, 0, 0,
+					TimeValue::PRECISION_DAY,
+					TimeParser::CALENDAR_GREGORIAN
+				),
 			),
 			'+0000000000000001-01-14T00:00:00Z (Julian)' => array(
-				TimeValue::newFromArray( array(
-					'time' => '+0000000000000001-01-14T00:00:00Z',
-					'timezone' => 0,
-					'before' => 0,
-					'after' => 0,
-					'precision' => TimeValue::PRECISION_DAY,
-					'calendarmodel' => TimeFormatter::CALENDAR_JULIAN
-			) ),
-				$emptyOpts,
+				new TimeValue(
+					'+0000000000000001-01-14T00:00:00Z',
+					0, 0, 0,
+					TimeValue::PRECISION_DAY,
+					TimeParser::CALENDAR_JULIAN
+				),
 			),
 			'+0000000000010000-01-01T00:00:00Z (Gregorian)' => array(
-				TimeValue::newFromArray( array(
-					'time' => '+0000000000010000-01-01T00:00:00Z',
-					'timezone' => 0,
-					'before' => 0,
-					'after' => 0,
-					'precision' => TimeValue::PRECISION_DAY,
-					'calendarmodel' => TimeFormatter::CALENDAR_GREGORIAN
-			) ),
-				$emptyOpts,
+				new TimeValue(
+					'+0000000000010000-01-01T00:00:00Z',
+					0, 0, 0,
+					TimeValue::PRECISION_DAY,
+					TimeParser::CALENDAR_GREGORIAN
+				),
 			),
 			'-0000000000000001-01-01T00:00:00Z (Gregorian)' => array(
-				TimeValue::newFromArray( array(
-					'time' => '-0000000000000001-01-01T00:00:00Z',
-					'timezone' => 0,
-					'before' => 0,
-					'after' => 0,
-					'precision' => TimeValue::PRECISION_DAY,
-					'calendarmodel' => TimeFormatter::CALENDAR_GREGORIAN
-			) ),
-				$emptyOpts,
+				new TimeValue(
+					'-0000000000000001-01-01T00:00:00Z',
+					0, 0, 0,
+					TimeValue::PRECISION_DAY,
+					TimeParser::CALENDAR_GREGORIAN
+				),
 			),
 			'-00000000001-01-01T00:00:00Z (Gregorian)' => array(
-				TimeValue::newFromArray( array(
-					'time' => '-0000000000000001-01-01T00:00:00Z',
-					'timezone' => 0,
-					'before' => 0,
-					'after' => 0,
-					'precision' => TimeValue::PRECISION_DAY,
-					'calendarmodel' => TimeFormatter::CALENDAR_GREGORIAN
-			) ),
-				$emptyOpts,
+				new TimeValue(
+					'-0000000000000001-01-01T00:00:00Z',
+					0, 0, 0,
+					TimeValue::PRECISION_DAY,
+					TimeParser::CALENDAR_GREGORIAN
+				),
 			),
 			'-000001-01-01T00:00:00Z (Gregorian)' => array(
-				TimeValue::newFromArray( array(
-					'time' => '-0000000000000001-01-01T00:00:00Z',
-					'timezone' => 0,
-					'before' => 0,
-					'after' => 0,
-					'precision' => TimeValue::PRECISION_DAY,
-					'calendarmodel' => TimeFormatter::CALENDAR_GREGORIAN
-			) ),
-				$emptyOpts,
+				new TimeValue(
+					'-0000000000000001-01-01T00:00:00Z',
+					0, 0, 0,
+					TimeValue::PRECISION_DAY,
+					TimeParser::CALENDAR_GREGORIAN
+				),
 			),
 			'-1-01-01T00:00:00Z (Gregorian)' => array(
-				TimeValue::newFromArray( array(
-					'time' => '-0000000000000001-01-01T00:00:00Z',
-					'timezone' => 0,
-					'before' => 0,
-					'after' => 0,
-					'precision' => TimeValue::PRECISION_DAY,
-					'calendarmodel' => TimeFormatter::CALENDAR_GREGORIAN
-			) ),
-				$emptyOpts,
+				new TimeValue(
+					'-0000000000000001-01-01T00:00:00Z',
+					0, 0, 0,
+					TimeValue::PRECISION_DAY,
+					TimeParser::CALENDAR_GREGORIAN
+				),
 			),
 
-			//Tests with different options
+			// Tests with different options
 			'-1-01-02T00:00:00Z' => array(
-				TimeValue::newFromArray( array(
-					'time' => '-0000000000000001-01-02T00:00:00Z',
-					'timezone' => 0,
-					'before' => 0,
-					'after' => 0,
-					'precision' => TimeValue::PRECISION_DAY,
-					'calendarmodel' => TimeFormatter::CALENDAR_GREGORIAN
-			) ),
+				new TimeValue(
+					'-0000000000000001-01-02T00:00:00Z',
+					0, 0, 0,
+					TimeValue::PRECISION_DAY,
+					TimeParser::CALENDAR_GREGORIAN
+				),
 				$gregorianOpts,
 			),
 			'-1-01-03T00:00:00Z' => array(
-				TimeValue::newFromArray( array(
-					'time' => '-0000000000000001-01-03T00:00:00Z',
-					'timezone' => 0,
-					'before' => 0,
-					'after' => 0,
-					'precision' => TimeValue::PRECISION_DAY,
-					'calendarmodel' => TimeFormatter::CALENDAR_JULIAN
-			) ),
+				new TimeValue(
+					'-0000000000000001-01-03T00:00:00Z',
+					0, 0, 0,
+					TimeValue::PRECISION_DAY,
+					TimeParser::CALENDAR_JULIAN
+				),
 				$julianOpts,
 			),
 			'-1-01-04T00:00:00Z' => array(
-				TimeValue::newFromArray( array(
-					'time' => '-0000000000000001-01-04T00:00:00Z',
-					'timezone' => 0,
-					'before' => 0,
-					'after' => 0,
-					'precision' => TimeValue::PRECISION_10a,
-					'calendarmodel' => TimeFormatter::CALENDAR_GREGORIAN
-			) ),
+				new TimeValue(
+					'-0000000000000001-01-04T00:00:00Z',
+					0, 0, 0,
+					TimeValue::PRECISION_10a,
+					TimeParser::CALENDAR_GREGORIAN
+				),
 				$prec10aOpts,
 			),
 			'-1-01-05T00:00:00Z' => array(
-				TimeValue::newFromArray( array(
-					'time' => '-0000000000000001-01-05T00:00:00Z',
-					'timezone' => 0,
-					'before' => 0,
-					'after' => 0,
-					'precision' => TimeValue::PRECISION_DAY,
-					'calendarmodel' => TimeFormatter::CALENDAR_GREGORIAN
-			) ),
+				new TimeValue(
+					'-0000000000000001-01-05T00:00:00Z',
+					0, 0, 0,
+					TimeValue::PRECISION_DAY,
+					TimeParser::CALENDAR_GREGORIAN
+				),
 				$noPrecOpts,
 			),
 
 			'+1999-00-00T00:00:00Z' => array(
-				TimeValue::newFromArray( array(
-					'time' => '+0000000000001999-00-00T00:00:00Z',
-					'timezone' => 0,
-					'before' => 0,
-					'after' => 0,
-					'precision' => TimeValue::PRECISION_YEAR,
-					'calendarmodel' => TimeFormatter::CALENDAR_GREGORIAN
-			) ),
-				$noPrecOpts,
+				new TimeValue(
+					'+0000000000001999-00-00T00:00:00Z',
+					0, 0, 0,
+					TimeValue::PRECISION_YEAR,
+					TimeParser::CALENDAR_GREGORIAN
+				),
 			),
 			'+2000-00-00T00:00:00Z' => array(
-				TimeValue::newFromArray( array(
-					'time' => '+0000000000002000-00-00T00:00:00Z',
-					'timezone' => 0,
-					'before' => 0,
-					'after' => 0,
-					'precision' => TimeValue::PRECISION_YEAR,
-					'calendarmodel' => TimeFormatter::CALENDAR_GREGORIAN
-			) ),
-				$noPrecOpts,
+				new TimeValue(
+					'+0000000000002000-00-00T00:00:00Z',
+					0, 0, 0,
+					TimeValue::PRECISION_YEAR,
+					TimeParser::CALENDAR_GREGORIAN
+				),
 			),
 			'+2010-00-00T00:00:00Z' => array(
-				TimeValue::newFromArray( array(
-					'time' => '+0000000000002010-00-00T00:00:00Z',
-					'timezone' => 0,
-					'before' => 0,
-					'after' => 0,
-					'precision' => TimeValue::PRECISION_YEAR,
-					'calendarmodel' => TimeFormatter::CALENDAR_GREGORIAN
-			) ),
-				$noPrecOpts,
+				new TimeValue(
+					'+0000000000002010-00-00T00:00:00Z',
+					0, 0, 0,
+					TimeValue::PRECISION_YEAR,
+					TimeParser::CALENDAR_GREGORIAN
+				),
 			),
 
-			//Tests for correct precision when a bad precision is passed through the opts
-			//@see https://bugzilla.wikimedia.org/show_bug.cgi?id=62730
+			// Tests for correct precision when a bad precision is passed through the opts
+			// @see https://bugzilla.wikimedia.org/show_bug.cgi?id=62730
 			'+0000000000000012-12-00T00:00:00Z' => array(
-				TimeValue::newFromArray( array(
-					'time' => '+0000000000000012-12-00T00:00:00Z',
-					'timezone' => 0,
-					'before' => 0,
-					'after' => 0,
-					'precision' => TimeValue::PRECISION_MONTH,
-					'calendarmodel' => TimeFormatter::CALENDAR_GREGORIAN
-				) ),
+				new TimeValue(
+					'+0000000000000012-12-00T00:00:00Z',
+					0, 0, 0,
+					TimeValue::PRECISION_MONTH,
+					TimeParser::CALENDAR_GREGORIAN
+				),
 				$precDayOpts,
 			),
 
@@ -431,12 +334,14 @@ class TimeParserTest extends ValueParserTestBase {
 
 		$argLists = array();
 		foreach ( $valid as $key => $value ) {
-			list( $timeValue, $opts ) = $value;
-			// Because PHP turns some of them into ints/floats using black magic (string)
+			$timeValue = $value[0];
+			$options = isset( $value[1] ) ? $value[1] : new ParserOptions();
+
 			$argLists[] = array(
+				// Because PHP magically turns numeric keys into ints/floats
 				(string)$key,
 				$timeValue,
-				new TimeParser( new CalendarModelParser( $opts ), $opts )
+				new TimeParser( new CalendarModelParser( $options ), $options )
 			);
 		}
 


### PR DESCRIPTION
This is a trivial no-op change split from #27 to make it easier to review. This is pure code reformatting, the test cases are not touched. The only changes are:
* Use `new TimeValue` instead of `TimeValue::newFromArray`.
* Use `TimeParser::CALENDAR_...` constants instead of `TimeFormatter::CALENDAR_...`.

Bug: [T87574](https://phabricator.wikimedia.org/T87574)