### PR TITLE
Stop using formatter constants in parsers

### DIFF
--- a/src/ValueParsers/CalendarModelParser.php
+++ b/src/ValueParsers/CalendarModelParser.php
@@ -2,8 +2,6 @@
 
 namespace ValueParsers;
 
-use ValueFormatters\TimeFormatter;
-
 /**
  * ValueParser that parses the string representation of a calendar model.
  *
@@ -57,10 +55,10 @@ class CalendarModelParser extends StringValueParser {
 		}
 
 		switch ( $value ) {
-			case TimeFormatter::CALENDAR_GREGORIAN:
-				return TimeFormatter::CALENDAR_GREGORIAN;
-			case TimeFormatter::CALENDAR_JULIAN:
-				return TimeFormatter::CALENDAR_JULIAN;
+			case IsoTimestampParser::CALENDAR_GREGORIAN:
+				return IsoTimestampParser::CALENDAR_GREGORIAN;
+			case IsoTimestampParser::CALENDAR_JULIAN:
+				return IsoTimestampParser::CALENDAR_JULIAN;
 		}
 
 		return $this->getCalendarModelUriFromKey( $value );
@@ -81,9 +79,9 @@ class CalendarModelParser extends StringValueParser {
 			case 'gregorian':
 			case 'western':
 			case 'christian':
-				return TimeFormatter::CALENDAR_GREGORIAN;
+				return IsoTimestampParser::CALENDAR_GREGORIAN;
 			case 'julian':
-				return TimeFormatter::CALENDAR_JULIAN;
+				return IsoTimestampParser::CALENDAR_JULIAN;
 		}
 
 		throw new ParseException( 'Cannot parse calendar model', $value, self::FORMAT_NAME );

--- a/tests/ValueFormatters/TimeFormatterTest.php
+++ b/tests/ValueFormatters/TimeFormatterTest.php
@@ -14,6 +14,7 @@ use ValueFormatters\TimeFormatter;
  *
  * @licence GNU GPL v2+
  * @author H. Snater < mediawiki@snater.com >
+ * @author Thiemo Mättig
  */
 class TimeFormatterTest extends ValueFormatterTestBase {
 
@@ -39,70 +40,38 @@ class TimeFormatterTest extends ValueFormatterTestBase {
 	 * @see ValueFormatterTestBase::validProvider
 	 */
 	public function validProvider() {
+		$gregorian = 'http://www.wikidata.org/entity/Q1985727';
+		$julian = 'http://www.wikidata.org/entity/Q1985786';
+
 		$tests = array(
 			'+2013-07-16T00:00:00Z' => array(
 				'+00000002013-07-16T00:00:00Z',
-				0,
-				0,
-				0,
-				11,
-				TimeFormatter::CALENDAR_GREGORIAN
 			),
 			'+0000-01-01T00:00:00Z' => array(
 				'+00000000000-01-01T00:00:00Z',
-				0,
-				0,
-				0,
-				11,
-				TimeFormatter::CALENDAR_GREGORIAN
 			),
 			'+0001-01-14T00:00:00Z' => array(
 				'+00000000001-01-14T00:00:00Z',
-				0,
-				0,
-				0,
-				11,
-				TimeFormatter::CALENDAR_JULIAN
+				TimeValue::PRECISION_DAY,
+				$julian
 			),
 			'+10000-01-01T00:00:00Z' => array(
 				'+00000010000-01-01T00:00:00Z',
-				0,
-				0,
-				0,
-				11,
-				TimeFormatter::CALENDAR_GREGORIAN
 			),
 			'-0001-01-01T00:00:00Z' => array(
 				'-00000000001-01-01T00:00:00Z',
-				0,
-				0,
-				0,
-				11,
-				TimeFormatter::CALENDAR_GREGORIAN
 			),
 			'+2013-07-17T00:00:00Z' => array(
 				'+00000002013-07-17T00:00:00Z',
-				0,
-				0,
-				0,
-				10,
-				TimeFormatter::CALENDAR_GREGORIAN
+				TimeValue::PRECISION_MONTH,
 			),
 			'+2013-07-18T00:00:00Z' => array(
 				'+00000002013-07-18T00:00:00Z',
-				0,
-				0,
-				0,
-				9,
-				TimeFormatter::CALENDAR_GREGORIAN
+				TimeValue::PRECISION_YEAR,
 			),
 			'+2013-07-19T00:00:00Z' => array(
 				'+00000002013-07-19T00:00:00Z',
-				0,
-				0,
-				0,
-				8,
-				TimeFormatter::CALENDAR_GREGORIAN
+				TimeValue::PRECISION_10a,
 			),
 		);
 
@@ -112,8 +81,15 @@ class TimeFormatterTest extends ValueFormatterTestBase {
 		$options = new FormatterOptions();
 
 		foreach ( $tests as $expected => $args ) {
-			$timeValue = new TimeValue( $args[0], $args[1], $args[2], $args[3], $args[4], $args[5] );
-			$argLists[] = array( $timeValue, $expected, $options );
+			$timestamp = $args[0];
+			$precision = isset( $args[1] ) ? $args[1] : TimeValue::PRECISION_DAY;
+			$calendarModel = isset( $args[2] ) ? $args[2] : $gregorian;
+
+			$argLists[] = array(
+				new TimeValue( $timestamp, 0, 0, 0, $precision, $calendarModel ),
+				$expected,
+				$options
+			);
 		}
 
 		return $argLists;

--- a/tests/ValueParsers/CalendarModelParserTest.php
+++ b/tests/ValueParsers/CalendarModelParserTest.php
@@ -2,8 +2,8 @@
 
 namespace ValueParsers\Test;
 
-use ValueFormatters\TimeFormatter;
 use ValueParsers\CalendarModelParser;
+use ValueParsers\IsoTimestampParser;
 use ValueParsers\ParserOptions;
 
 /**
@@ -53,27 +53,27 @@ class CalendarModelParserTest extends ValueParserTestBase {
 	 */
 	public function validInputProvider() {
 		return array(
-			array( '', TimeFormatter::CALENDAR_GREGORIAN ),
-			array( 'Gregorian', TimeFormatter::CALENDAR_GREGORIAN ),
-			array( 'Julian', TimeFormatter::CALENDAR_JULIAN ),
+			array( '', IsoTimestampParser::CALENDAR_GREGORIAN ),
+			array( 'Gregorian', IsoTimestampParser::CALENDAR_GREGORIAN ),
+			array( 'Julian', IsoTimestampParser::CALENDAR_JULIAN ),
 
 			// White space
-			array( ' ', TimeFormatter::CALENDAR_GREGORIAN ),
-			array( ' Gregorian ', TimeFormatter::CALENDAR_GREGORIAN ),
-			array( ' Julian ', TimeFormatter::CALENDAR_JULIAN ),
+			array( ' ', IsoTimestampParser::CALENDAR_GREGORIAN ),
+			array( ' Gregorian ', IsoTimestampParser::CALENDAR_GREGORIAN ),
+			array( ' Julian ', IsoTimestampParser::CALENDAR_JULIAN ),
 
 			// Capitalization
-			array( 'GreGOrIAN', TimeFormatter::CALENDAR_GREGORIAN ),
-			array( 'julian', TimeFormatter::CALENDAR_JULIAN ),
-			array( 'JULIAN', TimeFormatter::CALENDAR_JULIAN ),
+			array( 'GreGOrIAN', IsoTimestampParser::CALENDAR_GREGORIAN ),
+			array( 'julian', IsoTimestampParser::CALENDAR_JULIAN ),
+			array( 'JULIAN', IsoTimestampParser::CALENDAR_JULIAN ),
 
 			// See https://en.wikipedia.org/wiki/Gregorian_calendar
-			array( 'Western', TimeFormatter::CALENDAR_GREGORIAN ),
-			array( 'Christian', TimeFormatter::CALENDAR_GREGORIAN ),
+			array( 'Western', IsoTimestampParser::CALENDAR_GREGORIAN ),
+			array( 'Christian', IsoTimestampParser::CALENDAR_GREGORIAN ),
 
 			// URIs
-			array( 'http://www.wikidata.org/entity/Q1985727', TimeFormatter::CALENDAR_GREGORIAN ),
-			array( 'http://www.wikidata.org/entity/Q1985786', TimeFormatter::CALENDAR_JULIAN ),
+			array( 'http://www.wikidata.org/entity/Q1985727', IsoTimestampParser::CALENDAR_GREGORIAN ),
+			array( 'http://www.wikidata.org/entity/Q1985786', IsoTimestampParser::CALENDAR_JULIAN ),
 
 			// Via OPT_CALENDAR_MODEL_URIS
 			array( 'Localized', 'Unlocalized' ),


### PR DESCRIPTION
`TimeParser` will be renamed to `IsoTimestampParser` in #39. That's why I'm using `as`. This will make the following patch super-trivial.