### PR TITLE
Trim leading zeros from year in TimeValue

### DIFF
--- a/src/DataValues/TimeValue.php
+++ b/src/DataValues/TimeValue.php
@@ -36,17 +36,17 @@ class TimeValue extends DataValueObject {
 	 * Gregorian and Julian dates use the same YMD ordered format, resembling ISO 8601, e.g.
 	 * +2013-01-01T00:00:00Z. In this format the year is always signed and padded with zero
 	 * characters to have between 4 and 16 digits. Month and day can be zero, indicating they are
-	 * unknown. The timezone suffix Z is meaningless and must be ignored. Use $timezone instead.
+	 * unknown. The timezone suffix Z is meaningless and must be ignored. Use getTimezone() instead.
 	 *
 	 * @see $timezone
 	 * @see $calendarModel
 	 *
 	 * @var string
 	 */
-	private $time;
+	private $timestamp;
 
 	/**
-	 * Unit used for the $after and $before values. Use one of the TimeValue::PRECISION_...
+	 * Unit used for the getBefore() and getAfter() values. Use one of the TimeValue::PRECISION_...
 	 * constants.
 	 *
 	 * @var int
@@ -70,7 +70,7 @@ class TimeValue extends DataValueObject {
 	private $before;
 
 	/**
-	 * Timezone information as an offset from UTC in minutes.
+	 * Time zone information as an offset from UTC in minutes.
 	 *
 	 * @var int Minutes
 	 */
@@ -87,27 +87,27 @@ class TimeValue extends DataValueObject {
 	/**
 	 * @since 0.1
 	 *
-	 * @param string $time timestamp in a format depending on the calendar model
-	 * @param int $timezone offset from UTC in minutes
-	 * @param int $before number of units given by the precision
-	 * @param int $after number of units given by the precision
-	 * @param int $precision one of the TimeValue::PRECISION_... constants
-	 * @param string $calendarModel an URI identifying the calendar model
+	 * @param string $timestamp Timestamp in a format depending on the calendar model.
+	 * @param int $timezone Time zone offset from UTC in minutes.
+	 * @param int $before Number of units given by the precision.
+	 * @param int $after Number of units given by the precision.
+	 * @param int $precision One of the TimeValue::PRECISION_... constants.
+	 * @param string $calendarModel An URI identifying the calendar model.
 	 *
 	 * @throws IllegalValueException
 	 */
-	public function __construct( $time, $timezone, $before, $after, $precision, $calendarModel ) {
-		if ( !is_string( $time ) || $time === '' ) {
-			throw new IllegalValueException( '$time must be a non-empty string' );
+	public function __construct( $timestamp, $timezone, $before, $after, $precision, $calendarModel ) {
+		if ( !is_string( $timestamp ) || $timestamp === '' ) {
+			throw new IllegalValueException( '$timestamp must be a non-empty string' );
 		}
 
 		// Leap seconds are a valid concept
 		if ( !preg_match(
 			'/^([-+])(\d{1,16})(-(?:0\d|1[012])-(?:[012]\d|3[01])T(?:[01]\d|2[0-3]):[0-5]\d:(?:[0-5]\d|6[012])Z)$/',
-			$time,
+			$timestamp,
 			$matches
 		) ) {
-			throw new IllegalValueException( '$time must be a YMD string resembling ISO 8601, given ' . $time );
+			throw new IllegalValueException( '$timestamp must be a YMD string resembling ISO 8601, given ' . $timestamp );
 		}
 
 		if ( !is_int( $timezone ) ) {
@@ -140,9 +140,10 @@ class TimeValue extends DataValueObject {
 		}
 
 		$year = $matches[2];
+		$year = ltrim( $year, '0' );
 		$year = str_pad( $year, 4, '0', STR_PAD_LEFT );
 
-		$this->time = $matches[1] . $year . $matches[3];
+		$this->timestamp = $matches[1] . $year . $matches[3];
 		$this->timezone = $timezone;
 		$this->before = $before;
 		$this->after = $after;
@@ -151,14 +152,14 @@ class TimeValue extends DataValueObject {
 	}
 
 	/**
-	 * @see $time
+	 * @see $timestamp
 	 *
 	 * @since 0.1
 	 *
 	 * @return string
 	 */
 	public function getTime() {
-		return $this->time;
+		return $this->timestamp;
 	}
 
 	/**
@@ -235,7 +236,7 @@ class TimeValue extends DataValueObject {
 	 * @return string
 	 */
 	public function getSortKey() {
-		return $this->time;
+		return $this->timestamp;
 	}
 
 	/**
@@ -270,8 +271,8 @@ class TimeValue extends DataValueObject {
 	 * @throws IllegalValueException
 	 */
 	public function unserialize( $value ) {
-		list( $time, $timezone, $before, $after, $precision, $calendarModel ) = json_decode( $value );
-		$this->__construct( $time, $timezone, $before, $after, $precision, $calendarModel );
+		list( $timestamp, $timezone, $before, $after, $precision, $calendarModel ) = json_decode( $value );
+		$this->__construct( $timestamp, $timezone, $before, $after, $precision, $calendarModel );
 	}
 
 	/**
@@ -283,7 +284,7 @@ class TimeValue extends DataValueObject {
 	 */
 	public function getArrayValue() {
 		return array(
-			'time' => $this->time,
+			'time' => $this->timestamp,
 			'timezone' => $this->timezone,
 			'before' => $this->before,
 			'after' => $this->after,
@@ -317,7 +318,7 @@ class TimeValue extends DataValueObject {
 	}
 
 	public function __toString() {
-		return $this->time;
+		return $this->timestamp;
 	}
 
 }

--- a/tests/DataValues/TimeValueTest.php
+++ b/tests/DataValues/TimeValueTest.php
@@ -30,19 +30,19 @@ class TimeValueTest extends DataValueTest {
 	public function validConstructorArgumentsProvider() {
 		return array(
 			array(
-				'+00000002013-01-01T00:00:00Z',
+				'+2013-01-01T00:00:00Z',
 				0, 0, 0,
 				TimeValue::PRECISION_SECOND,
 				'http://nyan.cat/original.php',
 			),
 			array(
-				'+00000002013-01-01T00:00:00Z',
+				'+2013-01-01T00:00:00Z',
 				7200, 9001, 9001,
 				TimeValue::PRECISION_Ga,
 				'http://nyan.cat/original.php',
 			),
 			array(
-				'+00000002013-01-01T00:00:00Z',
+				'+2013-01-01T00:00:00Z',
 				-7200, 0, 42,
 				TimeValue::PRECISION_YEAR,
 				'http://nyan.cat/original.php',
@@ -171,8 +171,6 @@ class TimeValueTest extends DataValueTest {
 
 	/**
 	 * @dataProvider instanceProvider
-	 * @param TimeValue $time
-	 * @param array $arguments
 	 */
 	public function testGetTime( TimeValue $time, array $arguments ) {
 		$this->assertEquals( $arguments[0], $time->getTime() );
@@ -180,8 +178,6 @@ class TimeValueTest extends DataValueTest {
 
 	/**
 	 * @dataProvider instanceProvider
-	 * @param TimeValue $time
-	 * @param array $arguments
 	 */
 	public function testGetTimezone( TimeValue $time, array $arguments ) {
 		$this->assertEquals( $arguments[1], $time->getTimezone() );
@@ -189,8 +185,6 @@ class TimeValueTest extends DataValueTest {
 
 	/**
 	 * @dataProvider instanceProvider
-	 * @param TimeValue $time
-	 * @param array $arguments
 	 */
 	public function testGetBefore( TimeValue $time, array $arguments ) {
 		$this->assertEquals( $arguments[2], $time->getBefore() );
@@ -198,8 +192,6 @@ class TimeValueTest extends DataValueTest {
 
 	/**
 	 * @dataProvider instanceProvider
-	 * @param TimeValue $time
-	 * @param array $arguments
 	 */
 	public function testGetAfter( TimeValue $time, array $arguments ) {
 		$this->assertEquals( $arguments[3], $time->getAfter() );
@@ -207,8 +199,6 @@ class TimeValueTest extends DataValueTest {
 
 	/**
 	 * @dataProvider instanceProvider
-	 * @param TimeValue $time
-	 * @param array $arguments
 	 */
 	public function testGetPrecision( TimeValue $time, array $arguments ) {
 		$this->assertEquals( $arguments[4], $time->getPrecision() );
@@ -216,8 +206,6 @@ class TimeValueTest extends DataValueTest {
 
 	/**
 	 * @dataProvider instanceProvider
-	 * @param TimeValue $time
-	 * @param array $arguments
 	 */
 	public function testGetCalendarModel( TimeValue $time, array $arguments ) {
 		$this->assertEquals( $arguments[5], $time->getCalendarModel() );
@@ -225,8 +213,6 @@ class TimeValueTest extends DataValueTest {
 
 	/**
 	 * @dataProvider instanceProvider
-	 * @param TimeValue $time
-	 * @param array $arguments
 	 */
 	public function testGetValue( TimeValue $time, array $arguments ) {
 		$this->assertTrue( $time->equals( $time->getValue() ) );
@@ -234,8 +220,6 @@ class TimeValueTest extends DataValueTest {
 
 	/**
 	 * @dataProvider unpaddedYearsProvider
-	 * @param string $year
-	 * @param string $expected
 	 */
 	public function testGivenUnpaddedYear_yearIsPadded( $year, $expected ) {
 		$timeValue = new TimeValue(
@@ -252,7 +236,9 @@ class TimeValueTest extends DataValueTest {
 			array( '+1', '+0001' ),
 			array( '-10', '-0010' ),
 			array( '+2015', '+2015' ),
-			array( '+0000000000000001', '+0000000000000001' ),
+			array( '+02015', '+2015' ),
+			array( '+00000010000', '+10000' ),
+			array( '+0000000000000001', '+0001' ),
 			array( '+9999999999999999', '+9999999999999999' ),
 		);
 	}

--- a/tests/ValueFormatters/TimeFormatterTest.php
+++ b/tests/ValueFormatters/TimeFormatterTest.php
@@ -37,14 +37,10 @@ class TimeFormatterTest extends ValueFormatterTestBase {
 
 	/**
 	 * @see ValueFormatterTestBase::validProvider
-	 *
-	 * @since 0.1
-	 *
-	 * @return array
 	 */
 	public function validProvider() {
 		$tests = array(
-			'+00000002013-07-16T00:00:00Z (Gregorian)' => array(
+			'+2013-07-16T00:00:00Z (Gregorian)' => array(
 				'+00000002013-07-16T00:00:00Z',
 				0,
 				0,
@@ -52,7 +48,7 @@ class TimeFormatterTest extends ValueFormatterTestBase {
 				11,
 				TimeFormatter::CALENDAR_GREGORIAN
 			),
-			'+00000000000-01-01T00:00:00Z (Gregorian)' => array(
+			'+0000-01-01T00:00:00Z (Gregorian)' => array(
 				'+00000000000-01-01T00:00:00Z',
 				0,
 				0,
@@ -60,7 +56,7 @@ class TimeFormatterTest extends ValueFormatterTestBase {
 				11,
 				TimeFormatter::CALENDAR_GREGORIAN
 			),
-			'+00000000001-01-14T00:00:00Z (Gregorian)' => array(
+			'+0001-01-14T00:00:00Z (Gregorian)' => array(
 				'+00000000001-01-14T00:00:00Z',
 				0,
 				0,
@@ -68,7 +64,7 @@ class TimeFormatterTest extends ValueFormatterTestBase {
 				11,
 				TimeFormatter::CALENDAR_JULIAN
 			),
-			'+00000010000-01-01T00:00:00Z (Gregorian)' => array(
+			'+10000-01-01T00:00:00Z (Gregorian)' => array(
 				'+00000010000-01-01T00:00:00Z',
 				0,
 				0,
@@ -76,7 +72,7 @@ class TimeFormatterTest extends ValueFormatterTestBase {
 				11,
 				TimeFormatter::CALENDAR_GREGORIAN
 			),
-			'-00000000001-01-01T00:00:00Z (Gregorian)' => array(
+			'-0001-01-01T00:00:00Z (Gregorian)' => array(
 				'-00000000001-01-01T00:00:00Z',
 				0,
 				0,
@@ -84,7 +80,7 @@ class TimeFormatterTest extends ValueFormatterTestBase {
 				11,
 				TimeFormatter::CALENDAR_GREGORIAN
 			),
-			'+00000002013-07-17T00:00:00Z (Gregorian)' => array(
+			'+2013-07-17T00:00:00Z (Gregorian)' => array(
 				'+00000002013-07-17T00:00:00Z',
 				0,
 				0,
@@ -92,7 +88,7 @@ class TimeFormatterTest extends ValueFormatterTestBase {
 				10,
 				TimeFormatter::CALENDAR_GREGORIAN
 			),
-			'+00000002013-07-18T00:00:00Z (Gregorian)' => array(
+			'+2013-07-18T00:00:00Z (Gregorian)' => array(
 				'+00000002013-07-18T00:00:00Z',
 				0,
 				0,
@@ -100,7 +96,7 @@ class TimeFormatterTest extends ValueFormatterTestBase {
 				9,
 				TimeFormatter::CALENDAR_GREGORIAN
 			),
-			'+00000002013-07-19T00:00:00Z (Gregorian)' => array(
+			'+2013-07-19T00:00:00Z (Gregorian)' => array(
 				'+00000002013-07-19T00:00:00Z',
 				0,
 				0,


### PR DESCRIPTION
This patch contains:
* Trim leading zeros from the year, but keep 4 digits. This is what XSD 1.0 and 1.1 say, see http://www.w3.org/TR/xmlschema11-2/#dateTime. Quote: "leading '0' digits are prohibited except to bring the digit count up to four.".
* Rename internal variables to "timestamp". That's more descriptive than "time". But don't change the public interface, that's not worth it.

Bug: [T66084](https://phabricator.wikimedia.org/T66084)