### PR TITLE
Remove misleading calendar model output

### DIFF
--- a/src/ValueFormatters/TimeFormatter.php
+++ b/src/ValueFormatters/TimeFormatter.php
@@ -17,11 +17,12 @@ use InvalidArgumentException;
  * @author H. Snater < mediawiki@snater.com >
  */
 class TimeFormatter extends ValueFormatterBase {
+
 	const CALENDAR_GREGORIAN = 'http://www.wikidata.org/entity/Q1985727';
 	const CALENDAR_JULIAN = 'http://www.wikidata.org/entity/Q1985786';
 
-	const OPT_LANGUAGE = 'language';
 	const OPT_CALENDARNAMES = 'calendars';
+
 	const OPT_TIME_ISO_FORMATTER = 'time iso formatter';
 
 	/**
@@ -32,13 +33,7 @@ class TimeFormatter extends ValueFormatterBase {
 	public function __construct( FormatterOptions $options = null ) {
 		parent::__construct( $options );
 
-		$this->defaultOption( self::OPT_LANGUAGE, null );
-
-		$this->defaultOption( self::OPT_CALENDARNAMES, array(
-			self::CALENDAR_GREGORIAN => 'Gregorian',
-			self::CALENDAR_JULIAN => 'Julian',
-		) );
-
+		$this->defaultOption( self::OPT_CALENDARNAMES, array() );
 		$this->defaultOption( self::OPT_TIME_ISO_FORMATTER, null );
 	}
 
@@ -65,10 +60,7 @@ class TimeFormatter extends ValueFormatterBase {
 			$formatted = $isoFormatter->format( $value );
 		}
 
-		$calendarNames = $this->getOption( self::OPT_CALENDARNAMES );
-
-		// TODO: Support other calendar models retrieved via $value->getCalendarModel().
-		return $formatted . ' (' . $calendarNames[self::CALENDAR_GREGORIAN] . ')';
+		return $formatted;
 	}
 
 }

--- a/tests/ValueFormatters/TimeFormatterTest.php
+++ b/tests/ValueFormatters/TimeFormatterTest.php
@@ -40,7 +40,7 @@ class TimeFormatterTest extends ValueFormatterTestBase {
 	 */
 	public function validProvider() {
 		$tests = array(
-			'+2013-07-16T00:00:00Z (Gregorian)' => array(
+			'+2013-07-16T00:00:00Z' => array(
 				'+00000002013-07-16T00:00:00Z',
 				0,
 				0,
@@ -48,7 +48,7 @@ class TimeFormatterTest extends ValueFormatterTestBase {
 				11,
 				TimeFormatter::CALENDAR_GREGORIAN
 			),
-			'+0000-01-01T00:00:00Z (Gregorian)' => array(
+			'+0000-01-01T00:00:00Z' => array(
 				'+00000000000-01-01T00:00:00Z',
 				0,
 				0,
@@ -56,7 +56,7 @@ class TimeFormatterTest extends ValueFormatterTestBase {
 				11,
 				TimeFormatter::CALENDAR_GREGORIAN
 			),
-			'+0001-01-14T00:00:00Z (Gregorian)' => array(
+			'+0001-01-14T00:00:00Z' => array(
 				'+00000000001-01-14T00:00:00Z',
 				0,
 				0,
@@ -64,7 +64,7 @@ class TimeFormatterTest extends ValueFormatterTestBase {
 				11,
 				TimeFormatter::CALENDAR_JULIAN
 			),
-			'+10000-01-01T00:00:00Z (Gregorian)' => array(
+			'+10000-01-01T00:00:00Z' => array(
 				'+00000010000-01-01T00:00:00Z',
 				0,
 				0,
@@ -72,7 +72,7 @@ class TimeFormatterTest extends ValueFormatterTestBase {
 				11,
 				TimeFormatter::CALENDAR_GREGORIAN
 			),
-			'-0001-01-01T00:00:00Z (Gregorian)' => array(
+			'-0001-01-01T00:00:00Z' => array(
 				'-00000000001-01-01T00:00:00Z',
 				0,
 				0,
@@ -80,7 +80,7 @@ class TimeFormatterTest extends ValueFormatterTestBase {
 				11,
 				TimeFormatter::CALENDAR_GREGORIAN
 			),
-			'+2013-07-17T00:00:00Z (Gregorian)' => array(
+			'+2013-07-17T00:00:00Z' => array(
 				'+00000002013-07-17T00:00:00Z',
 				0,
 				0,
@@ -88,7 +88,7 @@ class TimeFormatterTest extends ValueFormatterTestBase {
 				10,
 				TimeFormatter::CALENDAR_GREGORIAN
 			),
-			'+2013-07-18T00:00:00Z (Gregorian)' => array(
+			'+2013-07-18T00:00:00Z' => array(
 				'+00000002013-07-18T00:00:00Z',
 				0,
 				0,
@@ -96,7 +96,7 @@ class TimeFormatterTest extends ValueFormatterTestBase {
 				9,
 				TimeFormatter::CALENDAR_GREGORIAN
 			),
-			'+2013-07-19T00:00:00Z (Gregorian)' => array(
+			'+2013-07-19T00:00:00Z' => array(
 				'+00000002013-07-19T00:00:00Z',
 				0,
 				0,


### PR DESCRIPTION
This patch simply removes the discussed, confusing calendar model display from this formatter. It's split from #49 (and will cause merge conflicts, but I would like to discuss the two changes in two independent pull requests).

Note that this formatter is currently unused. The Wikibase UI uses the `HtmlTimeFormatter` instead (which, by the way, uses the calendar model as "actual" and not "preferred calendar").

This patch also removes dead code that is not used anywhere, most notably the redundant language option.