### PR TITLE
Move MonthNameUnlocalizer and PhpDateTimeParser from WB.git

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ DataValues Time has been written by the Wikidata team, as [Wikimedia Germany]
 
 ### 0.7.0 (dev)
 
+* Added `MonthNameUnlocalizer`
+* Added `PhpDateTimeParser`
 * The year in Gregorian and Julian `TimeValue`s is now padded to at least 4 digits
 * Empty strings are now detected as invalid calendar models in the `TimeValue` constructor
 * Major update of the `TimeValue` documentation

--- a/src/ValueParsers/MonthNameUnlocalizer.php
+++ b/src/ValueParsers/MonthNameUnlocalizer.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace ValueParsers;
+
+/**
+ * Base class to unlocalize a month name in a date string.
+ *
+ * @since 0.7
+ *
+ * @licence GNU GPL v2+
+ * @author Adam Shorland
+ * @author Thiemo Mättig
+ */
+class MonthNameUnlocalizer {
+
+	/**
+	 * @var string[] An array mapping localized to canonical month names.
+	 */
+	private $replacements = array();
+
+	/**
+	 * @param string[] $replacements An array mapping localized month names (possibly including full
+	 * month names, genitive names and abbreviations) to canonical month names.
+	 */
+	public function __construct( array $replacements ) {
+		$this->replacements = $replacements;
+
+		// Order search strings from longest to shortest
+		uksort( $this->replacements, function( $a, $b ) {
+			return strlen( $b ) - strlen( $a );
+		} );
+	}
+
+	/**
+	 * Unlocalizes the longest month name in a date string that could be found first.
+	 * Tries to avoid doing multiple replacements and returns the localized original if in doubt.
+	 *
+	 * @see NumberUnlocalizer::unlocalizeNumber
+	 *
+	 * @param string $date Localized date string.
+	 *
+	 * @return string Unlocalized date string.
+	 */
+	public function unlocalize( $date ) {
+		foreach ( $this->replacements as $search => $replace ) {
+			$unlocalized = str_replace( $search, $replace, $date, $count );
+
+			// Nothing happened, try the next.
+			if ( $count <= 0 ) {
+				continue;
+			}
+
+			// Do not mess with strings that are clearly not a valid date.
+			if ( $count > 1 ) {
+				break;
+			}
+
+			// Do not mess with already unlocalized month names, e.g. "July" should not become
+			// "Julyy" when replacing "Jul" with "July". But shortening "Julyus" to "July" is ok.
+			if ( strpos( $date, $replace ) !== false && strlen( $replace ) >= strlen( $search ) ) {
+				break;
+			}
+
+			return $unlocalized;
+		}
+
+		return $date;
+	}
+
+}

--- a/src/ValueParsers/PhpDateTimeParser.php
+++ b/src/ValueParsers/PhpDateTimeParser.php
@@ -1,0 +1,199 @@
+<?php
+
+namespace ValueParsers;
+
+use DataValues\TimeValue;
+use DateTime;
+use Exception;
+
+/**
+ * Time parser using PHP's DateTime object. Since the behavior of PHP's parser can be quite odd
+ * (for example, it pads missing elements with the current date and does actual calculations such as
+ * parsing "2015-00-00" as "2014-12-30") this parser should only be used as a fallback.
+ *
+ * This class implements heuristics to guess which sequence of digits in the input represents the
+ * year. This is relevant because PHP's parser can only handle 4-digit years as expected. The
+ * following criteria are used to identify the year:
+ *
+ * - The first number longer than 2 digits or bigger than 59.
+ * - The first number in the input, if it is bigger than 31.
+ * - The third of three space-separated parts at the beginning of the input, if it is a number.
+ * - The third number in the input.
+ * - The last number in the input otherwise.
+ *
+ * @since 0.7
+ *
+ * @licence GNU GPL v2+
+ * @author Adam Shorland
+ * @author Thiemo Mättig
+ */
+class PhpDateTimeParser extends StringValueParser {
+
+	const FORMAT_NAME = 'datetime';
+
+	/**
+	 * @var MonthNameUnlocalizer
+	 */
+	private $monthNameUnlocalizer;
+
+	/**
+	 * @var ValueParser
+	 */
+	private $eraParser;
+
+	/**
+	 * @var ValueParser
+	 */
+	private $isoTimestampParser;
+
+	/**
+	 * @param MonthNameUnlocalizer $monthNameUnlocalizer Used to translate month names to English,
+	 * the language PHP's DateTime parser understands.
+	 * @param ValueParser $eraParser String parser that detects signs, "BC" suffixes and such and
+	 * returns an array with the detected sign character and the remaining value.
+	 * @param ValueParser $isoTimestampParser String parser that gets a language independend
+	 * YMD-ordered timestamp and returns a TimeValue object. Used for precision detection.
+	 */
+	public function __construct(
+		MonthNameUnlocalizer $monthNameUnlocalizer,
+		ValueParser $eraParser,
+		ValueParser $isoTimestampParser
+	) {
+		parent::__construct();
+
+		$this->monthNameUnlocalizer = $monthNameUnlocalizer;
+		$this->eraParser = $eraParser;
+		$this->isoTimestampParser = $isoTimestampParser;
+	}
+
+	/**
+	 * @param string $value in a format as specified by the PHP DateTime object
+	 *       there are exceptions as we can handel 5+ digit dates
+	 *
+	 * @throws ParseException
+	 * @return TimeValue
+	 */
+	protected function stringParse( $value ) {
+		$rawValue = $value;
+
+		try {
+			list( $sign, $value ) = $this->eraParser->parse( $value );
+
+			$value = trim( $value );
+			$value = $this->monthNameUnlocalizer->unlocalize( $value );
+			$year = $this->fetchAndNormalizeYear( $value );
+			$value = $this->getValueWithFixedSeparators( $value );
+
+			$this->validateDateTimeInput( $value );
+
+			// Parse using the DateTime object (this will allow us to format the date in a nicer way)
+			$dateTime = new DateTime( $value );
+
+			// Fail if the DateTime object does calculations like changing 2015-00-00 to 2014-12-30.
+			if ( $year !== null && $dateTime->format( 'Y' ) !== substr( $year, -4 ) ) {
+				throw new ParseException( $value . ' is not a valid date.' );
+			}
+
+			if ( $year !== null && strlen( $year ) > 4 ) {
+				$timestamp = $sign . $year . $dateTime->format( '-m-d\TH:i:s\Z' );
+			} else {
+				$timestamp = $sign . $dateTime->format( 'Y-m-d\TH:i:s\Z' );
+			}
+
+			// Pass the reformatted string into a base parser that parses this +/-Y-m-d\TH:i:s\Z format with a precision
+			return $this->isoTimestampParser->parse( $timestamp );
+		} catch ( Exception $exception ) {
+			throw new ParseException( $exception->getMessage(), $rawValue, self::FORMAT_NAME );
+		}
+	}
+
+	/**
+	 * @param string $value
+	 *
+	 * @throws ParseException
+	 */
+	private function validateDateTimeInput( $value ) {
+		// we don't support input of non-digits only, such as 'x'.
+		if ( !preg_match( '/\d/', $value ) ) {
+			throw new ParseException( $value . ' is not a valid date.' );
+		}
+
+		// @todo i18n support for these exceptions
+		// we don't support dates in format of year + timezone
+		if ( preg_match( '/^\d{1,7}(\+\d*|\D*)$/', $value ) ) {
+			throw new ParseException( $value . ' is not a valid date.' );
+		}
+	}
+
+	/**
+	 * PHP's DateTime object does not accept spaces as separators between year, month and day,
+	 * e.g. dates like 20 12 2012, but we want to support them.
+	 * See http://de1.php.net/manual/en/datetime.formats.date.php
+	 *
+	 * @param string $value
+	 *
+	 * @return mixed
+	 */
+	private function getValueWithFixedSeparators( $value ) {
+		return preg_replace( '/(?<=\d)[.\s]\s*/', '.', $value );
+	}
+
+	/**
+	 * Tries to find and pad the sequence of digits in the input that represents the year.
+	 * Refer to the class level documentation for a description of the heuristics used.
+	 *
+	 * @param string &$value A time value string, possibly containing a year. If found, the year in
+	 * the string will be cut and padded to exactly 4 digits.
+	 *
+	 * @return string|null The full year, if found, not cut but padded to at least 4 digits.
+	 */
+	private function fetchAndNormalizeYear( &$value ) {
+		// NOTE: When changing the regex matching below, keep the class level
+		// documentation of the extraction heuristics up to date!
+		$patterns = array(
+			// Check if the string contains a number longer than 2 digits or bigger than 59.
+			'/(?<!\d)('           // can not be prepended by a digit
+				. '\d{3,}|'       // any number longer than 2 digits, or
+				. '[6-9]\d'       // any number bigger than 59
+				. ')(?!\d)/',     // can not be followed by a digit
+
+			// Check if the first number in the string is bigger than 31.
+			'/^\D*(3[2-9]|[4-9]\d)/',
+
+			// Check if the string starts with three space-separated parts or three numbers.
+			'/^(?:'
+				. '\S+\s+\S+\s+|' // e.g. "July<SPACE>4th<SPACE>", or
+				. '\d+\D+\d+\D+'  // e.g. "4.7."
+				. ')(\d+)/',      // followed by a number
+
+			// Check if the string ends with a number.
+			'/(\d+)\D*$/',
+		);
+
+		foreach ( $patterns as $pattern ) {
+			if ( preg_match( $pattern, $value, $matches, PREG_OFFSET_CAPTURE ) ) {
+				break;
+			}
+		}
+
+		if ( !isset( $matches[1] ) ) {
+			return null;
+		}
+
+		$year = $matches[1][0];
+		$index = $matches[1][1];
+		$length = strlen( $year );
+
+		// Trim irrelevant leading zeros.
+		$year = ltrim( $year, '0' );
+
+		// Pad to at least 4 digits.
+		$year = str_pad( $year, 4, '0', STR_PAD_LEFT );
+
+		// Manipulate the value to have an exactly 4-digit year. Crucial for PHP's DateTime object.
+		$value = substr_replace( $value, substr( $year, -4 ), $index, $length );
+
+		return $year;
+	}
+
+}

--- a/tests/ValueParsers/MonthNameUnlocalizerTest.php
+++ b/tests/ValueParsers/MonthNameUnlocalizerTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace ValueParsers\Test;
+
+use PHPUnit_Framework_TestCase;
+use ValueParsers\MonthNameUnlocalizer;
+
+/**
+ * @covers ValueParsers\MonthNameUnlocalizer
+ *
+ * @group ValueParsers
+ * @group WikibaseLib
+ * @group Wikibase
+ *
+ * @licence GNU GPL v2+
+ * @author Adam Shorland
+ * @author Thiemo Mättig
+ */
+class MonthNameUnlocalizerTest extends PHPUnit_Framework_TestCase {
+
+	/**
+	 * @dataProvider localizedDateProvider
+	 */
+	public function testUnlocalize(
+		$date,
+		$expected,
+		array $replacements
+	) {
+		$unlocalizer = new MonthNameUnlocalizer( $replacements );
+
+		$this->assertEquals( $expected, $unlocalizer->unlocalize( $date ) );
+	}
+
+	public function localizedDateProvider() {
+		return array(
+			// No replacements given
+			array( '', '', array() ),
+			array( 'Jul', 'Jul', array() ),
+
+			// Longer strings do have higher priority
+			array( 'Juli', 'July', array(
+				'Jul' => 'bad',
+				'Juli' => 'July',
+			) ),
+			array( 'Juli', 'July', array(
+				'Juli' => 'July',
+				'Jul' => 'bad',
+			) ),
+
+			// Do not mess with strings that are clearly not a valid date.
+			array( 'July July', 'July July', array(
+				'July' => 'bad',
+			) ),
+
+			// Do not mess with already unlocalized month names.
+			array( 'July', 'July', array(
+				'Jul' => 'July',
+			) ),
+
+			// But shortening is ok even if a substring looks like it's already unlocalized.
+			array( 'July', 'Jul', array(
+				'July' => 'Jul',
+			) ),
+
+			// Word boundaries currently do not prevent unlocalization on purpose.
+			array( '1Jul2015', '1July2015', array(
+				'Jul' => 'July',
+			) ),
+			array( '1stJulLastYear', '1stJulyLastYear', array(
+				'Jul' => 'July',
+			) ),
+
+			// Capitalization is currently significant. This may need to depend on the languages.
+			array( 'jul', 'jul', array(
+				'Jul' => 'bad',
+			) ),
+		);
+	}
+
+}

--- a/tests/ValueParsers/PhpDateTimeParserTest.php
+++ b/tests/ValueParsers/PhpDateTimeParserTest.php
@@ -1,0 +1,291 @@
+<?php
+
+namespace ValueParsers\Test;
+
+use DataValues\TimeValue;
+use ValueParsers\CalendarModelParser;
+use ValueParsers\IsoTimestampParser;
+use ValueParsers\MonthNameUnlocalizer;
+use ValueParsers\ParserOptions;
+use ValueParsers\PhpDateTimeParser;
+use ValueParsers\ValueParser;
+
+/**
+ * @covers ValueParsers\PhpDateTimeParser
+ *
+ * @group ValueParsers
+ * @group WikibaseLib
+ * @group Wikibase
+ * @group TimeParsers
+ *
+ * @licence GNU GPL v2+
+ * @author Adam Shorland
+ * @author Thiemo Mättig
+ */
+class PhpDateTimeParserTest extends StringValueParserTest {
+
+	/**
+	 * @deprecated since 0.3, just use getInstance.
+	 */
+	protected function getParserClass() {
+		throw new \LogicException( 'Should not be called, use getInstance' );
+	}
+
+	/**
+	 * @see ValueParserTestBase::getInstance
+	 *
+	 * @return PhpDateTimeParser
+	 */
+	protected function getInstance() {
+		$options = new ParserOptions();
+
+		return new PhpDateTimeParser(
+			new MonthNameUnlocalizer( array() ),
+			$this->getEraParser(),
+			new IsoTimestampParser( new CalendarModelParser( $options ), $options )
+		);
+	}
+
+	/**
+	 * @return ValueParser
+	 */
+	private function getEraParser() {
+		$mock = $this->getMockBuilder( 'ValueParsers\ValueParser' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$mock->expects( $this->any() )
+			->method( 'parse' )
+			->with( $this->isType( 'string' ) )
+			->will( $this->returnCallback(
+				function( $value ) {
+					$sign = '+';
+					// Tiny parser that supports a single negative sign only
+					if ( $value[0] === '-' ) {
+						$sign = '-';
+						$value = substr( $value, 1 );
+					}
+					return array( $sign, $value ) ;
+				}
+			) );
+
+		return $mock;
+	}
+
+	/**
+	 * @see ValueParserTestBase::validInputProvider
+	 */
+	public function validInputProvider() {
+		$argList = array();
+
+		$valid = array(
+			// Normal/easy dates
+			'10/10/2010' =>
+				array( '+0000000000002010-10-10T00:00:00Z' ),
+			'10.10.2010' =>
+				array( '+0000000000002010-10-10T00:00:00Z' ),
+			'  10.  10.  2010  ' =>
+				array( '+0000000000002010-10-10T00:00:00Z' ),
+			'10 10 2010' =>
+				array( '+0000000000002010-10-10T00:00:00Z' ),
+			'10/10/0010' =>
+				array( '+0000000000000010-10-10T00:00:00Z' ),
+			'1 July 2013' =>
+				array( '+0000000000002013-07-01T00:00:00Z' ),
+			'1. July 2013' =>
+				array( '+0000000000002013-07-01T00:00:00Z' ),
+			'1 Jul 2013' =>
+				array( '+0000000000002013-07-01T00:00:00Z' ),
+			'January 9 1920' =>
+				array( '+0000000000001920-01-09T00:00:00Z' ),
+			'Feb 11 1930' =>
+				array( '+0000000000001930-02-11T00:00:00Z' ),
+			'1st July 2013' =>
+				array( '+0000000000002013-07-01T00:00:00Z' ),
+			'2nd July 2013' =>
+				array( '+0000000000002013-07-02T00:00:00Z' ),
+			'3rd July 2013' =>
+				array( '+0000000000002013-07-03T00:00:00Z' ),
+			'1th July 2013' =>
+				array( '+0000000000002013-07-01T00:00:00Z' ),
+			'2th July 2013' =>
+				array( '+0000000000002013-07-02T00:00:00Z' ),
+			'3th July 2013' =>
+				array( '+0000000000002013-07-03T00:00:00Z' ),
+			'4th July 2013' =>
+				array( '+0000000000002013-07-04T00:00:00Z' ),
+
+			// Year first dates
+			'2009-01-09' =>
+				array( '+0000000000002009-01-09T00:00:00Z' ),
+			'55-01-09' =>
+				array( '+0000000000000055-01-09T00:00:00Z' ),
+			'555-01-09' =>
+				array( '+0000000000000555-01-09T00:00:00Z' ),
+			'33300-1-1' =>
+				array( '+0000000000033300-01-01T00:00:00Z' ),
+			'3330002-1-1' =>
+				array( '+0000000003330002-01-01T00:00:00Z' ),
+
+			// Less than 4 digit years
+			'10/10/10' =>
+				array( '+0000000000000010-10-10T00:00:00Z' ),
+			'9 Jan 09' =>
+				array( '+0000000000000009-01-09T00:00:00Z' ),
+			'1/1/1' =>
+				array( '+0000000000000001-01-01T00:00:00Z' ),
+			'1-1-1' =>
+				array( '+0000000000000001-01-01T00:00:00Z' ),
+			'31-1-55' =>
+				array( '+0000000000000055-01-31T00:00:00Z' ),
+			'10-10-100' =>
+				array( '+0000000000000100-10-10T00:00:00Z' ),
+			'4th July 11' =>
+				array( '+0000000000000011-07-04T00:00:00Z' ),
+			'4th July 111' =>
+				array( '+0000000000000111-07-04T00:00:00Z' ),
+			'4th July 1' =>
+				array( '+0000000000000001-07-04T00:00:00Z' ),
+			'12.Jun.10x' =>
+				array( '+0000000000000010-06-12T00:00:00Z' ),
+
+			// More than 4 digit years
+			'4th July 10000' =>
+				array( '+0000000000010000-07-04T00:00:00Z' ),
+			'10/10/22000' =>
+				array( '+0000000000022000-10-10T00:00:00Z' ),
+			'1-1-33300' =>
+				array( '+0000000000033300-01-01T00:00:00Z' ),
+			'4th July 7214614279199781' =>
+				array( '+7214614279199781-07-04T00:00:00Z' ),
+			'-10100-02-29' =>
+				array( '-0000000000010100-03-01T00:00:00Z' ),
+
+			// Years with leading zeros
+			'009-08-07' =>
+				array( '+0000000000000009-08-07T00:00:00Z' ),
+			'000001-07-04' =>
+				array( '+0000000000000001-07-04T00:00:00Z' ),
+			'0000001-07-04' =>
+				array( '+0000000000000001-07-04T00:00:00Z' ),
+			'00000001-07-04' =>
+				array( '+0000000000000001-07-04T00:00:00Z' ),
+			'000000001-07-04' =>
+				array( '+0000000000000001-07-04T00:00:00Z' ),
+			'00000000000-07-04' =>
+				array( '+0000000000000000-07-04T00:00:00Z' ),
+			'4th July 00000002015' =>
+				array( '+0000000000002015-07-04T00:00:00Z' ),
+			'00000002015-07-04' =>
+				array( '+0000000000002015-07-04T00:00:00Z' ),
+			'4th July 00000092015' =>
+				array( '+0000000000092015-07-04T00:00:00Z' ),
+			'00000092015-07-04' =>
+				array( '+0000000000092015-07-04T00:00:00Z' ),
+
+			// Hour, minute and second precision
+			'4 July 2015 23:59' =>
+				array( '+0000000000002015-07-04T23:59:00Z', 0, 0, 0, TimeValue::PRECISION_MINUTE ),
+			'4 July 100 23:59' =>
+				array( '+0000000000000100-07-04T23:59:00Z', 0, 0, 0, TimeValue::PRECISION_MINUTE ),
+			'4 July 015 23:59' =>
+				array( '+0000000000000015-07-04T23:59:00Z', 0, 0, 0, TimeValue::PRECISION_MINUTE ),
+			'4 July 15 23:59' =>
+				array( '+0000000000000015-07-04T23:59:00Z', 0, 0, 0, TimeValue::PRECISION_MINUTE ),
+			'4.7.015 23:59' =>
+				array( '+0000000000000015-07-04T23:59:00Z', 0, 0, 0, TimeValue::PRECISION_MINUTE ),
+			'4.7.15 23:59' =>
+				array( '+0000000000000015-07-04T23:59:00Z', 0, 0, 0, TimeValue::PRECISION_MINUTE ),
+			'4/7/015 23:59' =>
+				array( '+0000000000000015-04-07T23:59:00Z', 0, 0, 0, TimeValue::PRECISION_MINUTE ),
+			'4/7/15 23:59' =>
+				array( '+0000000000000015-04-07T23:59:00Z', 0, 0, 0, TimeValue::PRECISION_MINUTE ),
+			'4th July 2015 12:00' =>
+				array( '+0000000000002015-07-04T12:00:00Z', 0, 0, 0, TimeValue::PRECISION_HOUR ),
+			'2015-07-04 12:00' =>
+				array( '+0000000000002015-07-04T12:00:00Z', 0, 0, 0, TimeValue::PRECISION_HOUR ),
+			'2015-07-04 12:30' =>
+				array( '+0000000000002015-07-04T12:30:00Z', 0, 0, 0, TimeValue::PRECISION_MINUTE ),
+			'2015-07-04 12:30:29' =>
+				array( '+0000000000002015-07-04T12:30:29Z', 0, 0, 0, TimeValue::PRECISION_SECOND ),
+			'15.07.04 23:59' =>
+				array( '+0000000000000004-07-15T23:59:00Z', 0, 0, 0, TimeValue::PRECISION_MINUTE ),
+			'15.07.04 00:01' =>
+				array( '+0000000000000004-07-15T00:01:00Z', 0, 0, 0, TimeValue::PRECISION_MINUTE ),
+			'15-07-01 12:37:00' =>
+				array( '+0000000000000001-07-15T12:37:00Z', 0, 0, 0, TimeValue::PRECISION_MINUTE ),
+			'4th July 15 12:00' =>
+				array( '+0000000000000015-07-04T12:00:00Z', 0, 0, 0, TimeValue::PRECISION_HOUR ),
+			'July 4th 15 12:00' =>
+				array( '+0000000000000015-07-04T12:00:00Z', 0, 0, 0, TimeValue::PRECISION_HOUR ),
+
+			// Testing leap year stuff
+			'10000-02-29' =>
+				array( '+0000000000010000-02-29T00:00:00Z' ),
+			'10100-02-29' =>
+				array( '+0000000000010100-03-01T00:00:00Z' ),
+			'10400-02-29' =>
+				array( '+0000000000010400-02-29T00:00:00Z' ),
+		);
+
+		foreach ( $valid as $value => $args ) {
+			$expected = new TimeValue(
+				$args[0],
+				array_key_exists( 1, $args ) ? $args[1] : 0,
+				array_key_exists( 2, $args ) ? $args[2] : 0,
+				array_key_exists( 3, $args ) ? $args[3] : 0,
+				array_key_exists( 4, $args ) ? $args[4] : TimeValue::PRECISION_DAY,
+				array_key_exists( 5, $args ) ? $args[5] : IsoTimestampParser::CALENDAR_GREGORIAN
+			);
+			$argList[] = array( (string)$value, $expected );
+		}
+
+		return $argList;
+	}
+
+	/**
+	 * @see StringValueParserTest::invalidInputProvider
+	 */
+	public function invalidInputProvider() {
+		$argLists = parent::invalidInputProvider();
+
+		$invalid = array(
+			// These are just wrong!
+			'June June June',
+			'111 111 111',
+			'101st July 2015',
+			'2015-07-101',
+			'10  .10  .2010',
+			'10...10...2010',
+			'00-00-00',
+			'99-00-00',
+			'111-00-00',
+			'2015-00-00',
+			'00000000099-00-00',
+			'00000002015-00-00',
+			'92015-00-00',
+			'Jann 2014',
+			'1980x',
+			'1980s', // supported by MWTimeIsoParser
+			'1980',
+			'1980ss',
+			'1980er',
+			'1980UTC', // we don't support year + timezone here
+			'1980America/New_York',
+			'1980 America/New_York',
+			'1980+3',
+			'1980+x',
+			'x',
+			'x x x',
+			'zz',
+			'America/New_York'
+		);
+
+		foreach ( $invalid as $value ) {
+			$argLists[] = array( $value );
+		}
+
+		return $argLists;
+	}
+
+}


### PR DESCRIPTION
I carefully prepared the two classes to make them independent from Wikibase.git. Now it's time to move them. Almost nothing needed to change, only the namespaces, the since tags and the EraParser mock.

Bug: [T96137](https://phabricator.wikimedia.org/T96137)