### PR TITLE
Replace intval() with faster type cast

### DIFF
--- a/src/ValueParsers/IsoTimestampParser.php
+++ b/src/ValueParsers/IsoTimestampParser.php
@@ -125,15 +125,15 @@ class IsoTimestampParser extends StringValueParser {
 	 * @return int One of the TimeValue::PRECISION_... constants.
 	 */
 	private function getPrecision( array $timeParts ) {
-		if ( intval( $timeParts[6] ) > 0 ) {
+		if ( $timeParts[6] > 0 ) {
 			$precision = TimeValue::PRECISION_SECOND;
-		} elseif ( intval( $timeParts[5] ) > 0 ) {
+		} elseif ( $timeParts[5] > 0 ) {
 			$precision = TimeValue::PRECISION_MINUTE;
-		} elseif ( intval( $timeParts[4] ) > 0 ) {
+		} elseif ( $timeParts[4] > 0 ) {
 			$precision = TimeValue::PRECISION_HOUR;
-		} elseif ( intval( $timeParts[3] ) > 0 ) {
+		} elseif ( $timeParts[3] > 0 ) {
 			$precision = TimeValue::PRECISION_DAY;
-		} elseif ( intval( $timeParts[2] ) > 0 ) {
+		} elseif ( $timeParts[2] > 0 ) {
 			$precision = TimeValue::PRECISION_MONTH;
 		} else {
 			$precision = $this->getPrecisionFromYear( $timeParts[1] );


### PR DESCRIPTION
intval() is about 5 times slower than a type cast, no matter if it's done explicit (by explicitly stating (int)$string) or implicit (via $string > 0). The difference between the two is that intval() accepts a base, which is not needed in these cases.

Following the arguments given in https://forge.typo3.org/issues/54265