### PR TITLE
Fix allowed leap seconds range

### DIFF
--- a/src/DataValues/TimeValue.php
+++ b/src/DataValues/TimeValue.php
@@ -97,6 +97,10 @@ class TimeValue extends DataValueObject {
 	 * @throws IllegalValueException
 	 */
 	public function __construct( $timestamp, $timezone, $before, $after, $precision, $calendarModel ) {
+		if ( !is_string( $timestamp ) || $timestamp === '' ) {
+			throw new IllegalValueException( '$timestamp must be a non-empty string' );
+		}
+
 		if ( !is_int( $timezone ) ) {
 			throw new IllegalValueException( '$timezone must be an integer' );
 		} elseif ( $timezone < -12 * 3600 || $timezone > 14 * 3600 ) {
@@ -137,9 +141,7 @@ class TimeValue extends DataValueObject {
 	 * @return string
 	 */
 	private function normalizeIsoTimestamp( $timestamp ) {
-		if ( !is_string( $timestamp ) || $timestamp === '' ) {
-			throw new IllegalValueException( '$timestamp must be a non-empty string' );
-		} elseif ( !preg_match(
+		if ( !preg_match(
 			'/^([-+])(\d{1,16})-(\d\d)-(\d\d)T(\d\d):(\d\d):(\d\d)Z$/',
 			$timestamp,
 			$matches
@@ -157,10 +159,11 @@ class TimeValue extends DataValueObject {
 			throw new IllegalValueException( 'Hour out of allowed bounds' );
 		} elseif ( $minute > 59 ) {
 			throw new IllegalValueException( 'Minute out of allowed bounds' );
-		} elseif ( $second > 62 ) {
+		} elseif ( $second > 61 ) {
 			throw new IllegalValueException( 'Second out of allowed bounds' );
 		}
 
+		// Warning, never cast the year to integer to not run into 32-bit integer overflows!
 		$year = ltrim( $year, '0' );
 		$year = str_pad( $year, 4, '0', STR_PAD_LEFT );
 

--- a/tests/DataValues/TimeValueTest.php
+++ b/tests/DataValues/TimeValueTest.php
@@ -61,13 +61,13 @@ class TimeValueTest extends DataValueTest {
 				'http://nyan.cat/original.php'
 			),
 			'Minimum timestamp' => array(
-				'-9999999999999999-12-31T23:59:62Z',
+				'-9999999999999999-12-31T23:59:61Z',
 				0, 0, 0,
 				TimeValue::PRECISION_SECOND,
 				'http://nyan.cat/original.php'
 			),
 			'Maximum timestamp' => array(
-				'+9999999999999999-12-31T23:59:62Z',
+				'+9999999999999999-12-31T23:59:61Z',
 				0, 0, 0,
 				TimeValue::PRECISION_SECOND,
 				'http://nyan.cat/original.php'
@@ -174,7 +174,7 @@ class TimeValueTest extends DataValueTest {
 				'http://nyan.cat/original.php'
 			),
 			'Second out of range' => array(
-				'+00000002013-01-01T00:00:63Z',
+				'+00000002013-01-01T00:00:62Z',
 				0, 0, 0,
 				TimeValue::PRECISION_SECOND,
 				'http://nyan.cat/original.php'


### PR DESCRIPTION
[Bug: T97511](https://phabricator.wikimedia.org/T97511)

Side note: I did a bit of benchmarking on that class' constructor because I added quite some code recently. I was afraid I introduced a bottleneck but couldn't find one. The regex can not be avoided. Squishing the range checks into the regex (as it was before) does make construction ~5% faster but is not worth it in my opinion because it dramatically decreases readability. The majority of construction time is spend on the many `is_...` checks. None can be avoided.