### PR TITLE
Move calendar model constants to TimeValue

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ DataValues Time has been written by the Wikidata team, as [Wikimedia Germany]
 
 * `IsoTimestampParser` auto-detects the calendar model and does not default to Gregorian any more
 
+### 0.7.1 (alpha)
+
+* Added `TimeValue::CALENDAR_GREGORIAN` and `TimeValue::CALENDAR_JULIAN`
+* Deprecated `TimeFormatter::CALENDAR_GREGORIAN` and `TimeFormatter::CALENDAR_JULIAN`
+* Deprecated `IsoTimestampParser::CALENDAR_GREGORIAN` and `IsoTimestampParser::CALENDAR_JULIAN`
+
 ### 0.7.0 (2015-04-20)
 
 #### Breaking changes

--- a/src/DataValues/TimeValue.php
+++ b/src/DataValues/TimeValue.php
@@ -31,6 +31,16 @@ class TimeValue extends DataValueObject {
 	const PRECISION_SECOND = 14;
 
 	/**
+	 * @since 0.7.1
+	 */
+	const CALENDAR_GREGORIAN = 'http://www.wikidata.org/entity/Q1985727';
+
+	/**
+	 * @since 0.7.1
+	 */
+	const CALENDAR_JULIAN = 'http://www.wikidata.org/entity/Q1985786';
+
+	/**
 	 * Timestamp describing a point in time. The actual format depends on the calendar model.
 	 *
 	 * Gregorian and Julian dates use the same YMD ordered format, resembling ISO 8601, e.g.

--- a/src/ValueFormatters/TimeFormatter.php
+++ b/src/ValueFormatters/TimeFormatter.php
@@ -18,8 +18,15 @@ use InvalidArgumentException;
  */
 class TimeFormatter extends ValueFormatterBase {
 
-	const CALENDAR_GREGORIAN = 'http://www.wikidata.org/entity/Q1985727';
-	const CALENDAR_JULIAN = 'http://www.wikidata.org/entity/Q1985786';
+	/**
+	 * @deprecated since 0.7.1, use TimeValue::CALENDAR_GREGORIAN instead
+	 */
+	const CALENDAR_GREGORIAN = TimeValue::CALENDAR_GREGORIAN;
+
+	/**
+	 * @deprecated since 0.7.1, use TimeValue::CALENDAR_JULIAN instead
+	 */
+	const CALENDAR_JULIAN = TimeValue::CALENDAR_JULIAN;
 
 	const OPT_CALENDARNAMES = 'calendars';
 

--- a/src/ValueParsers/CalendarModelParser.php
+++ b/src/ValueParsers/CalendarModelParser.php
@@ -2,7 +2,7 @@
 
 namespace ValueParsers;
 
-use ValueFormatters\TimeFormatter;
+use DataValues\TimeValue;
 
 /**
  * ValueParser that parses the string representation of a calendar model.
@@ -57,10 +57,10 @@ class CalendarModelParser extends StringValueParser {
 		}
 
 		switch ( $value ) {
-			case TimeFormatter::CALENDAR_GREGORIAN:
-				return TimeFormatter::CALENDAR_GREGORIAN;
-			case TimeFormatter::CALENDAR_JULIAN:
-				return TimeFormatter::CALENDAR_JULIAN;
+			case TimeValue::CALENDAR_GREGORIAN:
+				return TimeValue::CALENDAR_GREGORIAN;
+			case TimeValue::CALENDAR_JULIAN:
+				return TimeValue::CALENDAR_JULIAN;
 		}
 
 		return $this->getCalendarModelUriFromKey( $value );
@@ -81,9 +81,9 @@ class CalendarModelParser extends StringValueParser {
 			case 'gregorian':
 			case 'western':
 			case 'christian':
-				return TimeFormatter::CALENDAR_GREGORIAN;
+				return TimeValue::CALENDAR_GREGORIAN;
 			case 'julian':
-				return TimeFormatter::CALENDAR_JULIAN;
+				return TimeValue::CALENDAR_JULIAN;
 		}
 
 		throw new ParseException( 'Cannot parse calendar model', $value, self::FORMAT_NAME );

--- a/src/ValueParsers/IsoTimestampParser.php
+++ b/src/ValueParsers/IsoTimestampParser.php
@@ -30,8 +30,16 @@ class IsoTimestampParser extends StringValueParser {
 	const OPT_PRECISION = 'precision';
 	const OPT_CALENDAR = 'calendar';
 
-	const CALENDAR_GREGORIAN = 'http://www.wikidata.org/entity/Q1985727';
-	const CALENDAR_JULIAN = 'http://www.wikidata.org/entity/Q1985786';
+	/**
+	 * @deprecated since 0.7.1, use TimeValue::CALENDAR_GREGORIAN instead
+	 */
+	const CALENDAR_GREGORIAN = TimeValue::CALENDAR_GREGORIAN;
+
+	/**
+	 * @deprecated since 0.7.1, use TimeValue::CALENDAR_JULIAN instead
+	 */
+	const CALENDAR_JULIAN = TimeValue::CALENDAR_JULIAN;
+
 	const PRECISION_NONE = 'noprecision';
 
 	/**
@@ -199,10 +207,10 @@ class IsoTimestampParser extends StringValueParser {
 		if ( $option !== null ) {
 			// The calendar model is an URI and URIs can't be case-insensitive
 			switch ( $option ) {
-				case self::CALENDAR_JULIAN:
-					return self::CALENDAR_JULIAN;
+				case TimeValue::CALENDAR_JULIAN:
+					return TimeValue::CALENDAR_JULIAN;
 				default:
-					return self::CALENDAR_GREGORIAN;
+					return TimeValue::CALENDAR_GREGORIAN;
 			}
 		}
 

--- a/tests/ValueFormatters/TimeFormatterTest.php
+++ b/tests/ValueFormatters/TimeFormatterTest.php
@@ -46,7 +46,7 @@ class TimeFormatterTest extends ValueFormatterTestBase {
 				0,
 				0,
 				11,
-				TimeFormatter::CALENDAR_GREGORIAN
+				TimeValue::CALENDAR_GREGORIAN
 			),
 			'+0000-01-01T00:00:00Z' => array(
 				'+00000000000-01-01T00:00:00Z',
@@ -54,7 +54,7 @@ class TimeFormatterTest extends ValueFormatterTestBase {
 				0,
 				0,
 				11,
-				TimeFormatter::CALENDAR_GREGORIAN
+				TimeValue::CALENDAR_GREGORIAN
 			),
 			'+0001-01-14T00:00:00Z' => array(
 				'+00000000001-01-14T00:00:00Z',
@@ -62,7 +62,7 @@ class TimeFormatterTest extends ValueFormatterTestBase {
 				0,
 				0,
 				11,
-				TimeFormatter::CALENDAR_JULIAN
+				TimeValue::CALENDAR_JULIAN
 			),
 			'+10000-01-01T00:00:00Z' => array(
 				'+00000010000-01-01T00:00:00Z',
@@ -70,7 +70,7 @@ class TimeFormatterTest extends ValueFormatterTestBase {
 				0,
 				0,
 				11,
-				TimeFormatter::CALENDAR_GREGORIAN
+				TimeValue::CALENDAR_GREGORIAN
 			),
 			'-0001-01-01T00:00:00Z' => array(
 				'-00000000001-01-01T00:00:00Z',
@@ -78,7 +78,7 @@ class TimeFormatterTest extends ValueFormatterTestBase {
 				0,
 				0,
 				11,
-				TimeFormatter::CALENDAR_GREGORIAN
+				TimeValue::CALENDAR_GREGORIAN
 			),
 			'+2013-07-17T00:00:00Z' => array(
 				'+00000002013-07-17T00:00:00Z',
@@ -86,7 +86,7 @@ class TimeFormatterTest extends ValueFormatterTestBase {
 				0,
 				0,
 				10,
-				TimeFormatter::CALENDAR_GREGORIAN
+				TimeValue::CALENDAR_GREGORIAN
 			),
 			'+2013-07-18T00:00:00Z' => array(
 				'+00000002013-07-18T00:00:00Z',
@@ -94,7 +94,7 @@ class TimeFormatterTest extends ValueFormatterTestBase {
 				0,
 				0,
 				9,
-				TimeFormatter::CALENDAR_GREGORIAN
+				TimeValue::CALENDAR_GREGORIAN
 			),
 			'+2013-07-19T00:00:00Z' => array(
 				'+00000002013-07-19T00:00:00Z',
@@ -102,7 +102,7 @@ class TimeFormatterTest extends ValueFormatterTestBase {
 				0,
 				0,
 				8,
-				TimeFormatter::CALENDAR_GREGORIAN
+				TimeValue::CALENDAR_GREGORIAN
 			),
 		);
 

--- a/tests/ValueParsers/CalendarModelParserTest.php
+++ b/tests/ValueParsers/CalendarModelParserTest.php
@@ -2,7 +2,7 @@
 
 namespace ValueParsers\Test;
 
-use ValueFormatters\TimeFormatter;
+use DataValues\TimeValue;
 use ValueParsers\CalendarModelParser;
 use ValueParsers\ParserOptions;
 
@@ -53,27 +53,27 @@ class CalendarModelParserTest extends ValueParserTestBase {
 	 */
 	public function validInputProvider() {
 		return array(
-			array( '', TimeFormatter::CALENDAR_GREGORIAN ),
-			array( 'Gregorian', TimeFormatter::CALENDAR_GREGORIAN ),
-			array( 'Julian', TimeFormatter::CALENDAR_JULIAN ),
+			array( '', TimeValue::CALENDAR_GREGORIAN ),
+			array( 'Gregorian', TimeValue::CALENDAR_GREGORIAN ),
+			array( 'Julian', TimeValue::CALENDAR_JULIAN ),
 
 			// White space
-			array( ' ', TimeFormatter::CALENDAR_GREGORIAN ),
-			array( ' Gregorian ', TimeFormatter::CALENDAR_GREGORIAN ),
-			array( ' Julian ', TimeFormatter::CALENDAR_JULIAN ),
+			array( ' ', TimeValue::CALENDAR_GREGORIAN ),
+			array( ' Gregorian ', TimeValue::CALENDAR_GREGORIAN ),
+			array( ' Julian ', TimeValue::CALENDAR_JULIAN ),
 
 			// Capitalization
-			array( 'GreGOrIAN', TimeFormatter::CALENDAR_GREGORIAN ),
-			array( 'julian', TimeFormatter::CALENDAR_JULIAN ),
-			array( 'JULIAN', TimeFormatter::CALENDAR_JULIAN ),
+			array( 'GreGOrIAN', TimeValue::CALENDAR_GREGORIAN ),
+			array( 'julian', TimeValue::CALENDAR_JULIAN ),
+			array( 'JULIAN', TimeValue::CALENDAR_JULIAN ),
 
 			// See https://en.wikipedia.org/wiki/Gregorian_calendar
-			array( 'Western', TimeFormatter::CALENDAR_GREGORIAN ),
-			array( 'Christian', TimeFormatter::CALENDAR_GREGORIAN ),
+			array( 'Western', TimeValue::CALENDAR_GREGORIAN ),
+			array( 'Christian', TimeValue::CALENDAR_GREGORIAN ),
 
 			// URIs
-			array( 'http://www.wikidata.org/entity/Q1985727', TimeFormatter::CALENDAR_GREGORIAN ),
-			array( 'http://www.wikidata.org/entity/Q1985786', TimeFormatter::CALENDAR_JULIAN ),
+			array( 'http://www.wikidata.org/entity/Q1985727', TimeValue::CALENDAR_GREGORIAN ),
+			array( 'http://www.wikidata.org/entity/Q1985786', TimeValue::CALENDAR_JULIAN ),
 
 			// Via OPT_CALENDAR_MODEL_URIS
 			array( 'Localized', 'Unlocalized' ),


### PR DESCRIPTION
The IsoTimestampParser class moved to this component recently (which raises the question if the deprecation is needed or if we can remove the constants right away). The TimeFormatter was living here for a longer time. Now that both are in the same component it does not make much sense to keep both constants. The migration was suggested several times in other pull requests.

You may ask if this is Wikidata-specific knowledge. I disagree. It's just a string, nothing more. Also note that it was living in this component for a long time before.