### PR TITLE
Optional colons in ISO time

### DIFF
--- a/src/ValueParsers/IsoTimestampParser.php
+++ b/src/ValueParsers/IsoTimestampParser.php
@@ -67,8 +67,8 @@ class IsoTimestampParser extends StringValueParser {
 		}
 
 		$timeParts = $this->splitTimeString( $value );
-		// Pad sign with 1 plus, year with 16 zeros and hour, minute and second with 2 zeros
-		$time = vsprintf( '%\'+1s%016s-%s-%sT%02s:%02s:%02sZ', $timeParts );
+		// Pad sign with 1 plus, year with 4 zeros and hour, minute and second with 2 zeros
+		$time = vsprintf( '%\'+1s%04s-%s-%sT%02s:%02s:%02sZ', $timeParts );
 		$precision = $this->getPrecision( $timeParts );
 		$calendarModel = $this->getCalendarModel( $timeParts[7] );
 
@@ -90,7 +90,7 @@ class IsoTimestampParser extends StringValueParser {
 		$pattern = '@^\s*'                                                //leading spaces
 			. "([-+\xE2\x88\x92]?)\\s*"                                   //sign
 			. '(\d{1,16})-(\d{2})-(\d{2})'                                //year, month and day
-			. '(?:T(\d{2}):(\d{2})(?::(\d{2}))?)?'                        //hour, minute and second
+			. '(?:T(\d{2}):?(\d{2})(?::?(\d{2}))?)?'                      //hour, minute and second
 			. 'Z?'                                                        //time zone
 			. '\s*\(?\s*' . CalendarModelParser::MODEL_PATTERN . '\s*\)?' //calendar model
 			. '\s*$@iu';                                                  //trailing spaces
@@ -108,7 +108,7 @@ class IsoTimestampParser extends StringValueParser {
 			throw new ParseException( 'Hour out of range', $value, self::FORMAT_NAME );
 		} elseif ( $matches[6] > 59 ) {
 			throw new ParseException( 'Minute out of range', $value, self::FORMAT_NAME );
-		} elseif ( $matches[7] > 62 ) {
+		} elseif ( $matches[7] > 61 ) {
 			throw new ParseException( 'Second out of range', $value, self::FORMAT_NAME );
 		}
 

--- a/tests/ValueParsers/IsoTimestampParserTest.php
+++ b/tests/ValueParsers/IsoTimestampParserTest.php
@@ -222,6 +222,16 @@ class IsoTimestampParserTest extends ValueParserTestBase {
 				TimeValue::PRECISION_DAY,
 			),
 
+			// Optional colons
+			'2015-01-01T161718' => array(
+				'+0000000000002015-01-01T16:17:18Z',
+				TimeValue::PRECISION_SECOND,
+			),
+			'2015-01-01T1617' => array(
+				'+0000000000002015-01-01T16:17:00Z',
+				TimeValue::PRECISION_MINUTE,
+			),
+
 			// Optional second
 			'2015-01-01T00:00' => array(
 				'+0000000000002015-01-01T00:00:00Z',
@@ -262,8 +272,8 @@ class IsoTimestampParserTest extends ValueParserTestBase {
 			),
 
 			// Leap seconds are a valid concept
-			'+2015-01-01T00:00:60Z' => array(
-				'+0000000000002015-01-01T00:00:60Z',
+			'+2015-01-01T00:00:61Z' => array(
+				'+0000000000002015-01-01T00:00:61Z',
 				TimeValue::PRECISION_SECOND,
 			),
 
@@ -279,16 +289,17 @@ class IsoTimestampParserTest extends ValueParserTestBase {
 		);
 
 		$argLists = array();
+
 		foreach ( $valid as $key => $value ) {
 			$timestamp = $value[0];
 			$precision = isset( $value[1] ) ? $value[1] : TimeValue::PRECISION_DAY;
-			$calendareModel = isset( $value[2] ) ? $value[2] : $gregorian;
+			$calendarModel = isset( $value[2] ) ? $value[2] : $gregorian;
 			$options = isset( $value[3] ) ? $value[3] : null;
 
 			$argLists[] = array(
 				// Because PHP magically turns numeric keys into ints/floats
 				(string)$key,
-				new TimeValue( $timestamp, 0, 0, 0, $precision, $calendareModel ),
+				new TimeValue( $timestamp, 0, 0, 0, $precision, $calendarModel ),
 				new IsoTimestampParser( new CalendarModelParser( $options ), $options )
 			);
 		}
@@ -311,11 +322,13 @@ class IsoTimestampParserTest extends ValueParserTestBase {
 			'1 June 2014',
 			'59-01-01',
 			'+59-01-01',
+			'+2015-12-31T23',
+			'+2015-12-31T23Z',
 			'+2015-13-01T00:00:00Z',
 			'+2015-01-32T00:00:00Z',
 			'+2015-01-01T24:00:00Z',
 			'+2015-01-01T00:60:00Z',
-			'+2015-01-01T00:00:63Z',
+			'+2015-01-01T00:00:62Z',
 			'1234567890873',
 			2134567890
 		);


### PR DESCRIPTION
This patch fixes several issues and adds a new feature:
* Colons in time are optional, e.g. T1530 or T153001 are valid times according to ISO.
* Reduce year padding to 4 digits for consistency with TimeValue.
* 3 leap seconds (60, 61 and 62) can not exist; for consistency with TimeValue (see #64).

[Bug: T97511](https://phabricator.wikimedia.org/T97511)