### PR TITLE
Simplify calendar model detection code

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ DataValues Time has been written by the Wikidata team, as [Wikimedia Germany]
 
 ## Release notes
 
+### 0.8.0 (alpha)
+
+* `IsoTimestampParser` auto-detects the calendar model and does not default to Gregorian any more
+
 ### 0.7.0 (2015-04-20)
 
 #### Breaking changes

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "0.7.x-dev"
+			"dev-master": "0.8.x-dev"
 		}
 	}
 }

--- a/src/ValueParsers/IsoTimestampParser.php
+++ b/src/ValueParsers/IsoTimestampParser.php
@@ -126,15 +126,15 @@ class IsoTimestampParser extends StringValueParser {
 	 * @return int One of the TimeValue::PRECISION_... constants.
 	 */
 	private function getPrecision( array $timeParts ) {
-		if ( intval( $timeParts[6] ) > 0 ) {
+		if ( $timeParts[6] > 0 ) {
 			$precision = TimeValue::PRECISION_SECOND;
-		} elseif ( intval( $timeParts[5] ) > 0 ) {
+		} elseif ( $timeParts[5] > 0 ) {
 			$precision = TimeValue::PRECISION_MINUTE;
-		} elseif ( intval( $timeParts[4] ) > 0 ) {
+		} elseif ( $timeParts[4] > 0 ) {
 			$precision = TimeValue::PRECISION_HOUR;
-		} elseif ( intval( $timeParts[3] ) > 0 ) {
+		} elseif ( $timeParts[3] > 0 ) {
 			$precision = TimeValue::PRECISION_DAY;
-		} elseif ( intval( $timeParts[2] ) > 0 ) {
+		} elseif ( $timeParts[2] > 0 ) {
 			$precision = TimeValue::PRECISION_MONTH;
 		} else {
 			$precision = $this->getPrecisionFromYear( $timeParts[1] );
@@ -151,17 +151,17 @@ class IsoTimestampParser extends StringValueParser {
 	}
 
 	/**
-	 * @param string $year
+	 * @param string $unsignedYear
 	 *
 	 * @return int One of the TimeValue::PRECISION_... constants.
 	 */
-	private function getPrecisionFromYear( $year ) {
+	private function getPrecisionFromYear( $unsignedYear ) {
 		// default to year precision for range 4000 BC to 4000
-		if ( $year >= -4000 && $year <= 4000 ) {
+		if ( $unsignedYear <= 4000 ) {
 			return TimeValue::PRECISION_YEAR;
 		}
 
-		$rightZeros = strlen( $year ) - strlen( rtrim( $year, '0' ) );
+		$rightZeros = strlen( $unsignedYear ) - strlen( rtrim( $unsignedYear, '0' ) );
 		$precision = TimeValue::PRECISION_YEAR - $rightZeros;
 		if ( $precision < TimeValue::PRECISION_Ga ) {
 			$precision = TimeValue::PRECISION_Ga;
@@ -187,16 +187,18 @@ class IsoTimestampParser extends StringValueParser {
 	 * @return string URI
 	 */
 	private function getCalendarModel( array $timeParts ) {
-		$calendarModelName = $timeParts[7];
+		list( $sign, $unsignedYear, , , , , , $calendarModel ) = $timeParts;
 
-		if ( !empty( $calendarModelName ) ) {
-			return $this->calendarModelParser->parse( $calendarModelName );
+		if ( !empty( $calendarModel ) ) {
+			return $this->calendarModelParser->parse( $calendarModel );
 		}
 
+		$option = $this->getOption( self::OPT_CALENDAR );
+
 		// Use the calendar given in the option, if given
-		if ( $this->getOption( self::OPT_CALENDAR ) !== null ) {
+		if ( $option !== null ) {
 			// The calendar model is an URI and URIs can't be case-insensitive
-			switch ( $this->getOption( self::OPT_CALENDAR ) ) {
+			switch ( $option ) {
 				case self::CALENDAR_JULIAN:
 					return self::CALENDAR_JULIAN;
 				default:
@@ -204,19 +206,11 @@ class IsoTimestampParser extends StringValueParser {
 			}
 		}
 
-		// Try to guess from the year.
-		$sign = $timeParts[0] ?: '+';
-		$year = ltrim( $timeParts[1], '0' );
-		$year = $year === '' ? '+0' : ( $sign . $year );
-
-		// For large year values, avoid conversion to integer
-		if ( strlen( $year ) > 5 ) {
-			return $sign === '+' ? self::CALENDAR_GREGORIAN : self::CALENDAR_JULIAN;
-		}
-
 		// The Gregorian calendar was introduced in October 1582,
 		// so we'll default to Julian for all years before that.
-		return $year < 1583 ? self::CALENDAR_JULIAN : self::CALENDAR_GREGORIAN;
+		return $sign === '-' || $unsignedYear <= 1582
+			? self::CALENDAR_JULIAN
+			: self::CALENDAR_GREGORIAN;
 	}
 
 }


### PR DESCRIPTION
As discussed in https://github.com/DataValues/Time/pull/66#discussion_r29860462. This is pure refactoring that doesn't change any semantics. Instead of first re-concatenating sign and year, both are checked independently. The strlen check is not necessary. Even if an INT32 "overflow" happens, it will not cause any trouble because PHP doesn't overflow like C.