### PR TITLE
Fix IsoTimestampParser on midnight

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ DataValues Time has been written by the Wikidata team, as [Wikimedia Germany]
 * Added `TimeValue::CALENDAR_GREGORIAN` and `TimeValue::CALENDAR_JULIAN`
 * Deprecated `TimeFormatter::CALENDAR_GREGORIAN` and `TimeFormatter::CALENDAR_JULIAN`
 * Deprecated `IsoTimestampParser::CALENDAR_GREGORIAN` and `IsoTimestampParser::CALENDAR_JULIAN`
+* Removed `IsoTimestampParser::PRECISION_NONE`, use `null` instead
+* Fixed `IsoTimestampParser` not being able to set precision to hour, minute or day on midnight
 
 ### 0.7.0 (2015-04-20)
 

--- a/src/ValueParsers/IsoTimestampParser.php
+++ b/src/ValueParsers/IsoTimestampParser.php
@@ -40,8 +40,6 @@ class IsoTimestampParser extends StringValueParser {
 	 */
 	const CALENDAR_JULIAN = TimeValue::CALENDAR_JULIAN;
 
-	const PRECISION_NONE = 'noprecision';
-
 	/**
 	 * @var CalendarModelParser
 	 */
@@ -58,7 +56,7 @@ class IsoTimestampParser extends StringValueParser {
 		parent::__construct( $options );
 
 		$this->defaultOption( self::OPT_CALENDAR, null );
-		$this->defaultOption( self::OPT_PRECISION, self::PRECISION_NONE );
+		$this->defaultOption( self::OPT_PRECISION, null );
 
 		$this->calendarModelParser = $calendarModelParser ?: new CalendarModelParser( $this->options );
 	}
@@ -150,8 +148,11 @@ class IsoTimestampParser extends StringValueParser {
 
 		$option = $this->getOption( self::OPT_PRECISION );
 
-		// It's impossible to increase precision via option, e.g. to month if no month is given
-		if ( is_int( $option ) && $option <= $precision ) {
+		// It's impossible to increase the detected precision via option, e.g. from year to month if
+		// no month is given. If a day is given it can be increased, relevant for midnight.
+		if ( is_int( $option )
+			&& ( $option <= $precision || $precision >= TimeValue::PRECISION_DAY )
+		) {
 			return $option;
 		}
 

--- a/tests/ValueParsers/IsoTimestampParserTest.php
+++ b/tests/ValueParsers/IsoTimestampParserTest.php
@@ -53,8 +53,8 @@ class IsoTimestampParserTest extends ValueParserTestBase {
 		$precDayOpts = new ParserOptions();
 		$precDayOpts->setOption( IsoTimestampParser::OPT_PRECISION, TimeValue::PRECISION_DAY );
 
-		$noPrecOpts = new ParserOptions();
-		$noPrecOpts->setOption( IsoTimestampParser::OPT_PRECISION, IsoTimestampParser::PRECISION_NONE );
+		$precSecondOpts = new ParserOptions();
+		$precSecondOpts->setOption( IsoTimestampParser::OPT_PRECISION, TimeValue::PRECISION_SECOND );
 
 		$valid = array(
 			// Empty options tests
@@ -205,7 +205,6 @@ class IsoTimestampParserTest extends ValueParserTestBase {
 				'-0001-01-05T00:00:00Z',
 				TimeValue::PRECISION_DAY,
 				$julian,
-				$noPrecOpts,
 			),
 
 			'+1999-00-00T00:00:00Z' => array(
@@ -304,6 +303,12 @@ class IsoTimestampParserTest extends ValueParserTestBase {
 				TimeValue::PRECISION_MONTH,
 				$julian,
 				$precDayOpts,
+			),
+			'+2015-01-01T00:00:00Z' => array(
+				'+2015-01-01T00:00:00Z',
+				TimeValue::PRECISION_SECOND,
+				$gregorian,
+				$precSecondOpts,
 			),
 
 			// Test Julian/Gregorian switch in October 1582.


### PR DESCRIPTION
See README. This fixes an actual bug, but because we block hour, minute and second precisions this is currently not relevant for Wikibase.git.