### PR TITLE
Harmonize year padding in IsoTimestampParser

### DIFF
--- a/src/ValueParsers/IsoTimestampParser.php
+++ b/src/ValueParsers/IsoTimestampParser.php
@@ -77,12 +77,12 @@ class IsoTimestampParser extends StringValueParser {
 
 		$timeParts = $this->splitTimeString( $value );
 		// Pad sign with 1 plus, year with 4 zeros and hour, minute and second with 2 zeros
-		$time = vsprintf( '%\'+1s%04s-%s-%sT%02s:%02s:%02sZ', $timeParts );
+		$timestamp = vsprintf( '%\'+1s%04s-%s-%sT%02s:%02s:%02sZ', $timeParts );
 		$precision = $this->getPrecision( $timeParts );
 		$calendarModel = $this->getCalendarModel( $timeParts );
 
 		try {
-			return new TimeValue( $time, 0, 0, 0, $precision, $calendarModel );
+			return new TimeValue( $timestamp, 0, 0, 0, $precision, $calendarModel );
 		} catch ( IllegalValueException $ex ) {
 			throw new ParseException( $ex->getMessage(), $value, self::FORMAT_NAME );
 		}

--- a/tests/ValueParsers/IsoTimestampParserTest.php
+++ b/tests/ValueParsers/IsoTimestampParserTest.php
@@ -59,72 +59,72 @@ class IsoTimestampParserTest extends ValueParserTestBase {
 		$valid = array(
 			// Empty options tests
 			'+0000000000002013-07-16T00:00:00Z' => array(
-				'+0000000000002013-07-16T00:00:00Z',
+				'+2013-07-16T00:00:00Z',
 				TimeValue::PRECISION_DAY,
 			),
 			'+0000000000002013-07-00T00:00:00Z' => array(
-				'+0000000000002013-07-00T00:00:00Z',
+				'+2013-07-00T00:00:00Z',
 				TimeValue::PRECISION_MONTH,
 			),
 			'+0000000000002013-00-00T00:00:00Z' => array(
-				'+0000000000002013-00-00T00:00:00Z',
+				'+2013-00-00T00:00:00Z',
 				TimeValue::PRECISION_YEAR,
 			),
 			'+0000000000000000-00-00T00:00:00Z' => array(
-				'+0000000000000000-00-00T00:00:00Z',
+				'+0000-00-00T00:00:00Z',
 				TimeValue::PRECISION_YEAR,
 				$julian
 			),
 			'+0000000000002000-00-00T00:00:00Z' => array(
-				'+0000000000002000-00-00T00:00:00Z',
+				'+2000-00-00T00:00:00Z',
 				TimeValue::PRECISION_YEAR,
 			),
 			'+0000000000008000-00-00T00:00:00Z' => array(
-				'+0000000000008000-00-00T00:00:00Z',
+				'+8000-00-00T00:00:00Z',
 				TimeValue::PRECISION_ka,
 			),
 			'+0000000000020000-00-00T00:00:00Z' => array(
-				'+0000000000020000-00-00T00:00:00Z',
+				'+20000-00-00T00:00:00Z',
 				TimeValue::PRECISION_10ka,
 			),
 			'+0000000000200000-00-00T00:00:00Z' => array(
-				'+0000000000200000-00-00T00:00:00Z',
+				'+200000-00-00T00:00:00Z',
 				TimeValue::PRECISION_100ka,
 			),
 			'+0000000002000000-00-00T00:00:00Z' => array(
-				'+0000000002000000-00-00T00:00:00Z',
+				'+2000000-00-00T00:00:00Z',
 				TimeValue::PRECISION_Ma,
 			),
 			'+0000000020000000-00-00T00:00:00Z' => array(
-				'+0000000020000000-00-00T00:00:00Z',
+				'+20000000-00-00T00:00:00Z',
 				TimeValue::PRECISION_10Ma,
 			),
 			'+0000000200000000-00-00T00:00:00Z' => array(
-				'+0000000200000000-00-00T00:00:00Z',
+				'+200000000-00-00T00:00:00Z',
 				TimeValue::PRECISION_100Ma,
 			),
 			'+0000002000000000-00-00T00:00:00Z' => array(
-				'+0000002000000000-00-00T00:00:00Z',
+				'+2000000000-00-00T00:00:00Z',
 				TimeValue::PRECISION_Ga,
 			),
 			'+0000020000000000-00-00T00:00:00Z' => array(
-				'+0000020000000000-00-00T00:00:00Z',
+				'+20000000000-00-00T00:00:00Z',
 				TimeValue::PRECISION_Ga,
 			),
 			'+0000200000000000-00-00T00:00:00Z' => array(
-				'+0000200000000000-00-00T00:00:00Z',
+				'+200000000000-00-00T00:00:00Z',
 				TimeValue::PRECISION_Ga,
 			),
 			'+0002000000000000-00-00T00:00:00Z' => array(
-				'+0002000000000000-00-00T00:00:00Z',
+				'+2000000000000-00-00T00:00:00Z',
 				TimeValue::PRECISION_Ga,
 			),
 			'+0020000000000000-00-00T00:00:00Z' => array(
-				'+0020000000000000-00-00T00:00:00Z',
+				'+20000000000000-00-00T00:00:00Z',
 				TimeValue::PRECISION_Ga,
 			),
 			'+0200000000000000-00-00T00:00:00Z' => array(
-				'+0200000000000000-00-00T00:00:00Z',
+				'+200000000000000-00-00T00:00:00Z',
 				TimeValue::PRECISION_Ga,
 			),
 			'+2000000000000000-00-00T00:00:00Z' => array(
@@ -137,105 +137,105 @@ class IsoTimestampParserTest extends ValueParserTestBase {
 				$julian
 			),
 			'+0000000000002013-07-16T00:00:00Z (Gregorian)' => array(
-				'+0000000000002013-07-16T00:00:00Z',
+				'+2013-07-16T00:00:00Z',
 				TimeValue::PRECISION_DAY,
 			),
 			'+0000000000000000-01-01T00:00:00Z (Gregorian)' => array(
-				'+0000000000000000-01-01T00:00:00Z',
+				'+0000-01-01T00:00:00Z',
 				TimeValue::PRECISION_DAY,
 
 			),
 			'+0000000000002001-01-14T00:00:00Z (Julian)' => array(
-				'+0000000000002001-01-14T00:00:00Z',
+				'+2001-01-14T00:00:00Z',
 				TimeValue::PRECISION_DAY,
 				$julian,
 			),
 			'+0000000000010000-01-01T00:00:00Z (Gregorian)' => array(
-				'+0000000000010000-01-01T00:00:00Z',
+				'+10000-01-01T00:00:00Z',
 				TimeValue::PRECISION_DAY,
 			),
 			'-0000000000000001-01-01T00:00:00Z (Gregorian)' => array(
-				'-0000000000000001-01-01T00:00:00Z',
+				'-0001-01-01T00:00:00Z',
 				TimeValue::PRECISION_DAY,
 				$gregorian
 			),
 			'-00000000001-01-01T00:00:00Z (Gregorian)' => array(
-				'-0000000000000001-01-01T00:00:00Z',
+				'-0001-01-01T00:00:00Z',
 				TimeValue::PRECISION_DAY,
 				$gregorian,
 				$julianOpts // overridden by explicit calendar in input string
 			),
 			'-00000000001-01-01T00:00:00Z (Julian)' => array(
-				'-0000000000000001-01-01T00:00:00Z',
+				'-0001-01-01T00:00:00Z',
 				TimeValue::PRECISION_DAY,
 				$julian,
 				$gregorianOpts // overridden by explicit calendar in input string
 			),
 			'-000001-01-01T00:00:00Z (Gregorian)' => array(
-				'-0000000000000001-01-01T00:00:00Z',
+				'-0001-01-01T00:00:00Z',
 				TimeValue::PRECISION_DAY,
 				$gregorian
 			),
 			'-1-01-01T00:00:00Z (Gregorian)' => array(
-				'-0000000000000001-01-01T00:00:00Z',
+				'-0001-01-01T00:00:00Z',
 				TimeValue::PRECISION_DAY,
 				$gregorian
 			),
 
 			// Tests with different options
 			'-1-01-02T00:00:00Z' => array(
-				'-0000000000000001-01-02T00:00:00Z',
+				'-0001-01-02T00:00:00Z',
 				TimeValue::PRECISION_DAY,
 				$gregorian,
 				$gregorianOpts,
 			),
 			'+2001-01-03T00:00:00Z' => array(
-				'+0000000000002001-01-03T00:00:00Z',
+				'+2001-01-03T00:00:00Z',
 				TimeValue::PRECISION_DAY,
 				$julian,
 				$julianOpts,
 			),
 			'-1-01-04T00:00:00Z' => array(
-				'-0000000000000001-01-04T00:00:00Z',
+				'-0001-01-04T00:00:00Z',
 				TimeValue::PRECISION_10a,
 				$julian,
 				$prec10aOpts,
 			),
 			'-1-01-05T00:00:00Z' => array(
-				'-0000000000000001-01-05T00:00:00Z',
+				'-0001-01-05T00:00:00Z',
 				TimeValue::PRECISION_DAY,
 				$julian,
 				$noPrecOpts,
 			),
 
 			'+1999-00-00T00:00:00Z' => array(
-				'+0000000000001999-00-00T00:00:00Z',
+				'+1999-00-00T00:00:00Z',
 				TimeValue::PRECISION_YEAR,
 			),
 			'+2000-00-00T00:00:00Z' => array(
-				'+0000000000002000-00-00T00:00:00Z',
+				'+2000-00-00T00:00:00Z',
 				TimeValue::PRECISION_YEAR,
 			),
 			'+2010-00-00T00:00:00Z' => array(
-				'+0000000000002010-00-00T00:00:00Z',
+				'+2010-00-00T00:00:00Z',
 				TimeValue::PRECISION_YEAR,
 			),
 
 			// Optional sign character
 			'2015-01-01T00:00:00Z' => array(
-				'+0000000000002015-01-01T00:00:00Z',
+				'+2015-01-01T00:00:00Z',
 				TimeValue::PRECISION_DAY,
 			),
 
 			// Optional time zone
 			'2015-01-01T00:00:00' => array(
-				'+0000000000002015-01-01T00:00:00Z',
+				'+2015-01-01T00:00:00Z',
 				TimeValue::PRECISION_DAY,
 			),
 
 			// Actual minus character from Unicode; roundtrip with TimeDetailsFormatter
 			"\xE2\x88\x922015-01-01T00:00:00" => array(
-				'-0000000000002015-01-01T00:00:00Z',
+				'-2015-01-01T00:00:00Z',
 				TimeValue::PRECISION_DAY,
 				$julian
 			),
@@ -252,55 +252,55 @@ class IsoTimestampParserTest extends ValueParserTestBase {
 
 			// Optional second
 			'2015-01-01T00:00' => array(
-				'+0000000000002015-01-01T00:00:00Z',
+				'+2015-01-01T00:00:00Z',
 				TimeValue::PRECISION_DAY,
 			),
 
 			// Optional hour and minute
 			'2015-01-01' => array(
-				'+0000000000002015-01-01T00:00:00Z',
+				'+2015-01-01T00:00:00Z',
 				TimeValue::PRECISION_DAY,
 			),
 			'60-01-01' => array(
-				'+0000000000000060-01-01T00:00:00Z',
+				'+0060-01-01T00:00:00Z',
 				TimeValue::PRECISION_DAY,
 				$julian
 			),
 
 			// Years < 60 require either the time part or a year with more than 2 digits
 			'1-01-01T00:00' => array(
-				'+0000000000000001-01-01T00:00:00Z',
+				'+0001-01-01T00:00:00Z',
 				TimeValue::PRECISION_DAY,
 				$julian
 			),
 			'001-01-01' => array(
-				'+0000000000000001-01-01T00:00:00Z',
+				'+0001-01-01T00:00:00Z',
 				TimeValue::PRECISION_DAY,
 				$julian
 			),
 
 			// Day zero
 			'2015-01-00' => array(
-				'+0000000000002015-01-00T00:00:00Z',
+				'+2015-01-00T00:00:00Z',
 				TimeValue::PRECISION_MONTH,
 			),
 
 			// Month zero
 			'2015-00-00' => array(
-				'+0000000000002015-00-00T00:00:00Z',
+				'+2015-00-00T00:00:00Z',
 				TimeValue::PRECISION_YEAR,
 			),
 
 			// Leap seconds are a valid concept
 			'+2015-01-01T00:00:61Z' => array(
-				'+0000000000002015-01-01T00:00:61Z',
+				'+2015-01-01T00:00:61Z',
 				TimeValue::PRECISION_SECOND,
 			),
 
 			// Tests for correct precision when a bad precision is passed through the opts
 			// @see https://bugzilla.wikimedia.org/show_bug.cgi?id=62730
 			'+0000000000000012-12-00T00:00:00Z' => array(
-				'+0000000000000012-12-00T00:00:00Z',
+				'+0012-12-00T00:00:00Z',
 				TimeValue::PRECISION_MONTH,
 				$julian,
 				$precDayOpts,
@@ -308,14 +308,14 @@ class IsoTimestampParserTest extends ValueParserTestBase {
 
 			// Test Julian/Gregorian switch in October 1582.
 			'1583-01-01' => array(
-				'+0000000000001583-01-01T00:00:00Z',
+				'+1583-01-01T00:00:00Z',
 				TimeValue::PRECISION_DAY,
 				$gregorian
 			),
 
 			// Test Julian/Gregorian switch in October 1582.
 			'1582-08-01' => array(
-				'+0000000000001582-08-01T00:00:00Z',
+				'+1582-08-01T00:00:00Z',
 				TimeValue::PRECISION_DAY,
 				$julian
 			),


### PR DESCRIPTION
All these paddings do not have an effect because `TimeValue` normalizes the timestamp anyway. But the code is easier to read and maintain if the year padding is the same everywhere.