### PR TITLE
Add old precision constants as aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,9 @@ DataValues Time has been written by the Wikidata team, as [Wikimedia Germany]
 
 ## Release notes
 
-### 0.8.0 (alpha)
+### 0.8.0 (2015-06-24)
 
 #### Breaking changes
-* Renamed all `TimeValue::PRECISION_...` constants with lower case letters, e.g. `PRECISION_10a` to `PRECISION_YEAR10`
 * `IsoTimestampParser` auto-detects the calendar model and does not default to Gregorian any more
 * Removed `IsoTimestampParser::PRECISION_NONE`, use `null` instead
 * `TimeValue`s leap second range changed from [0..62] to [0..61]
@@ -63,6 +62,8 @@ DataValues Time has been written by the Wikidata team, as [Wikimedia Germany]
 #### Additions
 * Added `EraParser`
 * Added `TimeValue::CALENDAR_GREGORIAN` and `TimeValue::CALENDAR_JULIAN`
+* Renamed all `TimeValue::PRECISION_...` constants with lower case letters, e.g. `PRECISION_10a` to
+  `PRECISION_YEAR10`, leaving backwards compatible aliases
 * `IsoTimestampParser` now accepts time values with optional colons, per ISO
 * `PhpDateTimeParser` now accepts comma separated dates
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ DataValues Time has been written by the Wikidata team, as [Wikimedia Germany]
 
 ## Release notes
 
-### 0.8.0 (2015-06-24)
+### 0.8.0 (2015-06-25)
 
 #### Breaking changes
 * `IsoTimestampParser` auto-detects the calendar model and does not default to Gregorian any more

--- a/Time.php
+++ b/Time.php
@@ -15,7 +15,7 @@ if ( defined( 'DATAVALUES_TIME_VERSION' ) ) {
 	return 1;
 }
 
-define( 'DATAVALUES_TIME_VERSION', '0.8.0 alpha' );
+define( 'DATAVALUES_TIME_VERSION', '0.8.0' );
 
 if ( defined( 'MEDIAWIKI' ) ) {
 	$GLOBALS['wgExtensionCredits']['datavalues'][] = array(

--- a/src/DataValues/TimeValue.php
+++ b/src/DataValues/TimeValue.php
@@ -14,15 +14,96 @@ namespace DataValues;
  */
 class TimeValue extends DataValueObject {
 
+	/**
+	 * @deprecated since 0.8, use PRECISION_YEAR1G instead
+	 */
+	const PRECISION_Ga = TimeValue::PRECISION_YEAR1G;
+
+	/**
+	 * @deprecated since 0.8, use PRECISION_YEAR100M instead
+	 */
+	const PRECISION_100Ma = TimeValue::PRECISION_YEAR100M;
+
+	/**
+	 * @deprecated since 0.8, use PRECISION_YEAR10M instead
+	 */
+	const PRECISION_10Ma = TimeValue::PRECISION_YEAR10M;
+
+	/**
+	 * @deprecated since 0.8, use PRECISION_YEAR1M instead
+	 */
+	const PRECISION_Ma = TimeValue::PRECISION_YEAR1M;
+
+	/**
+	 * @deprecated since 0.8, use PRECISION_YEAR100K instead
+	 */
+	const PRECISION_100ka = TimeValue::PRECISION_YEAR100K;
+
+	/**
+	 * @deprecated since 0.8, use PRECISION_YEAR10K instead
+	 */
+	const PRECISION_10ka = TimeValue::PRECISION_YEAR10K;
+
+	/**
+	 * @deprecated since 0.8, use PRECISION_YEAR1K instead
+	 */
+	const PRECISION_ka = TimeValue::PRECISION_YEAR1K;
+
+	/**
+	 * @deprecated since 0.8, use PRECISION_YEAR100 instead
+	 */
+	const PRECISION_100a = TimeValue::PRECISION_YEAR100;
+
+	/**
+	 * @deprecated since 0.8, use PRECISION_YEAR10 instead
+	 */
+	const PRECISION_10a = TimeValue::PRECISION_YEAR10;
+
+	/**
+	 * @since 0.8
+	 */
 	const PRECISION_YEAR1G = 0;
+
+	/**
+	 * @since 0.8
+	 */
 	const PRECISION_YEAR100M = 1;
+
+	/**
+	 * @since 0.8
+	 */
 	const PRECISION_YEAR10M = 2;
+
+	/**
+	 * @since 0.8
+	 */
 	const PRECISION_YEAR1M = 3;
+
+	/**
+	 * @since 0.8
+	 */
 	const PRECISION_YEAR100K = 4;
+
+	/**
+	 * @since 0.8
+	 */
 	const PRECISION_YEAR10K = 5;
+
+	/**
+	 * @since 0.8
+	 */
 	const PRECISION_YEAR1K = 6;
+
+	/**
+	 * @since 0.8
+	 */
 	const PRECISION_YEAR100 = 7;
+
+	/**
+	 * @since 0.8
+	 */
 	const PRECISION_YEAR10 = 8;
+
 	const PRECISION_YEAR = 9;
 	const PRECISION_MONTH = 10;
 	const PRECISION_DAY = 11;


### PR DESCRIPTION
This partly "reverts" #42 by re-adding backwards compatible aliases.

[Bug: T99911](https://phabricator.wikimedia.org/T99911)