### PR TITLE
Make CalendarModelParserTest more independent

### DIFF
--- a/tests/ValueParsers/CalendarModelParserTest.php
+++ b/tests/ValueParsers/CalendarModelParserTest.php
@@ -2,7 +2,6 @@
 
 namespace ValueParsers\Test;
 
-use DataValues\TimeValue;
 use ValueParsers\CalendarModelParser;
 use ValueParsers\ParserOptions;
 
@@ -52,28 +51,31 @@ class CalendarModelParserTest extends ValueParserTestBase {
 	 * @see ValueParserTestBase::validInputProvider
 	 */
 	public function validInputProvider() {
+		$gregorian = 'http://www.wikidata.org/entity/Q1985727';
+		$julian = 'http://www.wikidata.org/entity/Q1985786';
+
 		return array(
-			array( '', TimeValue::CALENDAR_GREGORIAN ),
-			array( 'Gregorian', TimeValue::CALENDAR_GREGORIAN ),
-			array( 'Julian', TimeValue::CALENDAR_JULIAN ),
+			array( '', $gregorian ),
+			array( 'Gregorian', $gregorian ),
+			array( 'Julian', $julian ),
 
 			// White space
-			array( ' ', TimeValue::CALENDAR_GREGORIAN ),
-			array( ' Gregorian ', TimeValue::CALENDAR_GREGORIAN ),
-			array( ' Julian ', TimeValue::CALENDAR_JULIAN ),
+			array( ' ', $gregorian ),
+			array( ' Gregorian ', $gregorian ),
+			array( ' Julian ', $julian ),
 
 			// Capitalization
-			array( 'GreGOrIAN', TimeValue::CALENDAR_GREGORIAN ),
-			array( 'julian', TimeValue::CALENDAR_JULIAN ),
-			array( 'JULIAN', TimeValue::CALENDAR_JULIAN ),
+			array( 'GreGOrIAN', $gregorian ),
+			array( 'julian', $julian ),
+			array( 'JULIAN', $julian ),
 
 			// See https://en.wikipedia.org/wiki/Gregorian_calendar
-			array( 'Western', TimeValue::CALENDAR_GREGORIAN ),
-			array( 'Christian', TimeValue::CALENDAR_GREGORIAN ),
+			array( 'Western', $gregorian ),
+			array( 'Christian', $gregorian ),
 
 			// URIs
-			array( 'http://www.wikidata.org/entity/Q1985727', TimeValue::CALENDAR_GREGORIAN ),
-			array( 'http://www.wikidata.org/entity/Q1985786', TimeValue::CALENDAR_JULIAN ),
+			array( 'http://www.wikidata.org/entity/Q1985727', $gregorian ),
+			array( 'http://www.wikidata.org/entity/Q1985786', $julian ),
 
 			// Via OPT_CALENDAR_MODEL_URIS
 			array( 'Localized', 'Unlocalized' ),


### PR DESCRIPTION
This makes this test more independent from a class it should not depend on. I already did the same in a lot of other tests in Wikibase.git.