### PR TITLE
Do not parse a HH:MM:SS time as a date

### DIFF
--- a/src/ValueParsers/YearMonthDayTimeParser.php
+++ b/src/ValueParsers/YearMonthDayTimeParser.php
@@ -67,6 +67,7 @@ class YearMonthDayTimeParser extends StringValueParser {
 			throw new ParseException( 'Can not find three numbers' );
 		}
 
+		// A 32 in the first spot can not be confused with anything.
 		if ( $matches[1] < 1 || $matches[1] > 31 ) {
 			// A format YDM does not exist.
 			if ( $matches[2] > 12 ) {
@@ -75,7 +76,11 @@ class YearMonthDayTimeParser extends StringValueParser {
 
 			// Since a format YDM does not exist, this must be YMD.
 			list( , $signedYear, $month, $day ) = $matches;
-		} elseif ( $matches[3] < 1 || $matches[3] > 31 ) {
+		} elseif ( $matches[3] < 1 || $matches[3] > 59
+			// A 59 in the third spot may be a second, but can not if the first number is > 24.
+			// A 31 in the last spot may be the day.
+			|| ( abs( $matches[1] ) > 24 && abs( $matches[3] ) > 31 )
+		) {
 			if ( $matches[1] > 12 ) {
 				list( , $day, $month, $signedYear ) = $matches;
 			} elseif ( $matches[2] > 12 ) {

--- a/tests/ValueParsers/YearMonthDayTimeParserTest.php
+++ b/tests/ValueParsers/YearMonthDayTimeParserTest.php
@@ -66,7 +66,7 @@ class YearMonthDayTimeParserTest extends StringValueParserTest {
 			// Julian
 			'32-12-31' => array( '+0032-12-31T00:00:00Z', $julian ),
 			'31.12.32' => array( '+0032-12-31T00:00:00Z', $julian ),
-			'12/31/32' => array( '+0032-12-31T00:00:00Z', $julian ),
+			'12/31/60' => array( '+0060-12-31T00:00:00Z', $julian ),
 
 			// Negative years
 			'-2015-12-31' => array( '-2015-12-31T00:00:00Z', $julian ),
@@ -112,6 +112,12 @@ class YearMonthDayTimeParserTest extends StringValueParserTest {
 			'31.12.2015 23',
 			'31.12.2015 23:59',
 			'+2015-12-31T00:00:00Z',
+
+			// Can be confused with a time (HMS)
+			'12:31:59',
+			'12:59:59',
+			'23:12:59',
+			'23:12:31',
 
 			// No year can be identified if all numbers are smaller than 32.
 			'12 12 12',


### PR DESCRIPTION
I suggest to merge #80 first because they conflict.

[Bug: T104862](https://phabricator.wikimedia.org/T104862)