### PR TITLE
YearMonthDayTimeParser must be aware of rare YDM format

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ DataValues Time has been written by the Wikidata team, as [Wikimedia Germany]
 
 ## Release notes
 
+### 0.8.2 (2015-08-18)
+
+* Fixed `YearMonthDayTimeParser` rejecting YDM dates
+
 ### 0.8.1 (2015-08-14)
 
 #### Additions

--- a/Time.php
+++ b/Time.php
@@ -15,7 +15,7 @@ if ( defined( 'DATAVALUES_TIME_VERSION' ) ) {
 	return 1;
 }
 
-define( 'DATAVALUES_TIME_VERSION', '0.8.1' );
+define( 'DATAVALUES_TIME_VERSION', '0.8.2' );
 
 if ( defined( 'MEDIAWIKI' ) ) {
 	$GLOBALS['wgExtensionCredits']['datavalues'][] = array(

--- a/src/ValueParsers/YearMonthDayTimeParser.php
+++ b/src/ValueParsers/YearMonthDayTimeParser.php
@@ -69,17 +69,17 @@ class YearMonthDayTimeParser extends StringValueParser {
 
 		// A 32 in the first spot can not be confused with anything.
 		if ( $matches[1] < 1 || $matches[1] > 31 ) {
-			// A format YDM does not exist.
 			if ( $matches[2] > 12 ) {
-				throw new ParseException( 'Can not accept YDM' );
+				list( , $signedYear, $day, $month ) = $matches;
+			} elseif ( $matches[3] > 12 ) {
+				list( , $signedYear, $month, $day ) = $matches;
+			} else {
+				throw new ParseException( 'Can not distinguish YDM and YMD' );
 			}
-
-			// Since a format YDM does not exist, this must be YMD.
-			list( , $signedYear, $month, $day ) = $matches;
 		} elseif ( $matches[3] < 1 || $matches[3] > 59
 			// A 59 in the third spot may be a second, but can not if the first number is > 24.
-			// A 31 in the last spot may be the day.
-			|| ( abs( $matches[1] ) > 24 && abs( $matches[3] ) > 31 )
+			// A 31 in the last spot may be the day, but can not if it's negative.
+			|| ( abs( $matches[1] ) > 24 && $matches[3] > 31 )
 		) {
 			if ( $matches[1] > 12 ) {
 				list( , $day, $month, $signedYear ) = $matches;

--- a/tests/ValueParsers/YearMonthDayTimeParserTest.php
+++ b/tests/ValueParsers/YearMonthDayTimeParserTest.php
@@ -45,10 +45,10 @@ class YearMonthDayTimeParserTest extends StringValueParserTest {
 		$julian = 'http://www.wikidata.org/entity/Q1985786';
 
 		$valid = array(
-			// YMD
+			// YMD, typically used in ISO 8601
 			'2015-12-31' => array( '+2015-12-31T00:00:00Z' ),
 			'2015 12 31' => array( '+2015-12-31T00:00:00Z' ),
-			'2015 12 11' => array( '+2015-12-11T00:00:00Z' ),
+			'2015 1 13' => array( '+2015-01-13T00:00:00Z' ),
 
 			// DMY
 			'31.12.2015' => array( '+2015-12-31T00:00:00Z' ),
@@ -58,10 +58,15 @@ class YearMonthDayTimeParserTest extends StringValueParserTest {
 			'31th 12th 2015' => array( '+2015-12-31T00:00:00Z' ),
 			'day 31, month 12, year 2015' => array( '+2015-12-31T00:00:00Z' ),
 
-			// MDY
+			// MDY, almost exclusively used in the United States
 			'12/31/2015' => array( '+2015-12-31T00:00:00Z' ),
 			'12-31-2015' => array( '+2015-12-31T00:00:00Z' ),
 			'12 31 2015' => array( '+2015-12-31T00:00:00Z' ),
+
+			// YDM, exclusively used in Kazakhstan
+			// https://en.wikipedia.org/wiki/Calendar_date#Gregorian.2C_year-day-month_.28YDM.29
+			'2015.31.12' => array( '+2015-12-31T00:00:00Z' ),
+			'2015 13 1' => array( '+2015-01-13T00:00:00Z' ),
 
 			// Julian
 			'32-12-31' => array( '+0032-12-31T00:00:00Z', $julian ),
@@ -80,6 +85,7 @@ class YearMonthDayTimeParserTest extends StringValueParserTest {
 			// A negative number must be the year.
 			'year -3-2-13' => array( '-0003-02-13T00:00:00Z', $julian ),
 			'13. 2. -3' => array( '-0003-02-13T00:00:00Z', $julian ),
+			'23:12:-59' => array( '-0059-12-23T00:00:00Z', $julian ),
 		);
 
 		$cases = array();
@@ -118,6 +124,8 @@ class YearMonthDayTimeParserTest extends StringValueParserTest {
 			'12:59:59',
 			'23:12:59',
 			'23:12:31',
+			'-23:12:31',
+			'-24:00:00',
 
 			// No year can be identified if all numbers are smaller than 32.
 			'12 12 12',
@@ -129,18 +137,21 @@ class YearMonthDayTimeParserTest extends StringValueParserTest {
 			'12 31 31',
 			'31 31 31',
 
-			// Year can be identified, but month and day can not be distinguished.
-			'12 32 12',
+			// Two or more candidates for the year.
 			'32 32 12',
-			'12 12 32',
 			'32 12 32',
 			'12 32 32',
 			'32 32 32',
 
-			// A YDM format does really exist and should not be parsed.
-			'2015 31 12',
+			// Year can be identified, but month and day can not be distinguished.
+			'32 12 12',
+			'2015-12-11',
+			'12 12 32',
+			'11.12.2015',
 
 			// Formats DYM and MYD do not exist and should not be parsed.
+			'12 -1 12',
+			'12 32 12',
 			'12 2015 31',
 			'31 2015 12',
 


### PR DESCRIPTION
You could say that this is a breaking change, because some inputs are now parsed different. E.g. "2015.12.11" was parsed before but is rejected now because the parser can not know if it's YMD or YDM.

I would argue that this is purely a bugfix. E.g. "2015.31.12" was rejected before but is accepted now. "2015.12.11" should have never been parsed. The contract of the class did not changed: Some inputs are accepted and some not. This did not changed. Code using this component should get this update silently.