### PR TITLE
YearMonthDayTimeParser can always accept month == day

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,11 @@ DataValues Time has been written by the Wikidata team, as [Wikimedia Germany]
 
 ## Release notes
 
-### 0.8.2 (2015-08-28)
+### 0.8.2 (2015-09-15)
 
 * Fixed `IsoTimestampParser` and `TimeValue` accepting days with no month.
 * Fixed `YearMonthDayTimeParser` rejecting YDM dates.
+* `YearMonthDayTimeParser` accepts some more dates where month and day are the same anyway.
 
 ### 0.8.1 (2015-08-14)
 

--- a/src/ValueParsers/YearMonthDayTimeParser.php
+++ b/src/ValueParsers/YearMonthDayTimeParser.php
@@ -6,8 +6,8 @@ use DataValues\IllegalValueException;
 use DataValues\TimeValue;
 
 /**
- * A straight time parser with a strict rule set that only accepts YMD, DMY and MDY formatted dates
- * if they can not be confused with an other format.
+ * A straight time parser with a strict rule set that only accepts YMD, DMY, MDY and YDM formatted
+ * dates if they can not be confused with an other format.
  *
  * @since 0.8.1
  *
@@ -69,10 +69,10 @@ class YearMonthDayTimeParser extends StringValueParser {
 
 		// A 32 in the first spot can not be confused with anything.
 		if ( $matches[1] < 1 || $matches[1] > 31 ) {
-			if ( $matches[2] > 12 ) {
-				list( , $signedYear, $day, $month ) = $matches;
-			} elseif ( $matches[3] > 12 ) {
+			if ( $matches[3] > 12 || $matches[2] == $matches[3] ) {
 				list( , $signedYear, $month, $day ) = $matches;
+			} elseif ( $matches[2] > 12 ) {
+				list( , $signedYear, $day, $month ) = $matches;
 			} else {
 				throw new ParseException( 'Can not distinguish YDM and YMD' );
 			}
@@ -81,7 +81,7 @@ class YearMonthDayTimeParser extends StringValueParser {
 			// A 31 in the last spot may be the day, but can not if it's negative.
 			|| ( abs( $matches[1] ) > 24 && $matches[3] > 31 )
 		) {
-			if ( $matches[1] > 12 ) {
+			if ( $matches[1] > 12 || $matches[1] == $matches[2] ) {
 				list( , $day, $month, $signedYear ) = $matches;
 			} elseif ( $matches[2] > 12 ) {
 				list( , $month, $day, $signedYear ) = $matches;

--- a/tests/ValueParsers/YearMonthDayTimeParserTest.php
+++ b/tests/ValueParsers/YearMonthDayTimeParserTest.php
@@ -68,6 +68,14 @@ class YearMonthDayTimeParserTest extends StringValueParserTest {
 			'2015.31.12' => array( '+2015-12-31T00:00:00Z' ),
 			'2015 13 1' => array( '+2015-01-13T00:00:00Z' ),
 
+			// Month and day are the same, does not matter if DMY or MDY
+			'01 1 2015' => array( '+2015-01-01T00:00:00Z' ),
+			'12 12 2015' => array( '+2015-12-12T00:00:00Z' ),
+
+			// Month and day are the same, does not matter if YMD or YDM
+			'2015 01 1' => array( '+2015-01-01T00:00:00Z' ),
+			'2015 12 12' => array( '+2015-12-12T00:00:00Z' ),
+
 			// Julian
 			'32-12-31' => array( '+0032-12-31T00:00:00Z', $julian ),
 			'31.12.32' => array( '+0032-12-31T00:00:00Z', $julian ),
@@ -144,9 +152,9 @@ class YearMonthDayTimeParserTest extends StringValueParserTest {
 			'32 32 32',
 
 			// Year can be identified, but month and day can not be distinguished.
-			'32 12 12',
+			'32 2 1',
 			'2015-12-11',
-			'12 12 32',
+			'1 2 32',
 			'11.12.2015',
 
 			// Formats DYM and MYD do not exist and should not be parsed.


### PR DESCRIPTION
This was already merged in #87, but not into master but into the #86 branch. I expected both to appear in master when merged in the right order, but according to the graph the merge commit in #87 did not became part of #86. Let's try again.