### PR TITLE
Set to 0 components more precise than the precision

### DIFF
--- a/src/DataValues/TimeValue.php
+++ b/src/DataValues/TimeValue.php
@@ -217,7 +217,7 @@ class TimeValue extends DataValueObject {
 			throw new IllegalValueException( '$calendarModel must be a non-empty string' );
 		}
 
-		$this->timestamp = $this->normalizeIsoTimestamp( $timestamp );
+		$this->timestamp = $this->normalizeIsoTimestamp( $timestamp, $precision );
 		$this->timezone = $timezone;
 		$this->before = $before;
 		$this->after = $after;
@@ -227,11 +227,12 @@ class TimeValue extends DataValueObject {
 
 	/**
 	 * @param string $timestamp
+	 * @param int $precision
 	 *
 	 * @throws IllegalValueException
 	 * @return string
 	 */
-	private function normalizeIsoTimestamp( $timestamp ) {
+	private function normalizeIsoTimestamp( $timestamp, $precision ) {
 		if ( !preg_match(
 			'/^([-+])(\d{1,16})-(\d\d)-(\d\d)T(\d\d):(\d\d):(\d\d)Z$/',
 			$timestamp,
@@ -259,6 +260,22 @@ class TimeValue extends DataValueObject {
 		// Warning, never cast the year to integer to not run into 32-bit integer overflows!
 		$year = ltrim( $year, '0' );
 		$year = str_pad( $year, 4, '0', STR_PAD_LEFT );
+
+		if ( $precision < self::PRECISION_MONTH ) {
+			$month = '00';
+		}
+		if ( $precision < self::PRECISION_DAY ) {
+			$day = '00';
+		}
+		if ( $precision < self::PRECISION_HOUR ) {
+			$hour = '00';
+		}
+		if ( $precision < self::PRECISION_MINUTE ) {
+			$minute = '00';
+		}
+		if ( $precision < self::PRECISION_SECOND ) {
+			$second = '00';
+		}
 
 		return $sign . $year . '-' . $month . '-' . $day . 'T' . $hour . ':' . $minute .':' . $second . 'Z';
 	}

--- a/tests/DataValues/TimeValueTest.php
+++ b/tests/DataValues/TimeValueTest.php
@@ -36,13 +36,13 @@ class TimeValueTest extends DataValueTest {
 				'http://nyan.cat/original.php'
 			),
 			'Maximum timezone' => array(
-				'+2013-01-01T00:00:00Z',
+				'+2013-00-00T00:00:00Z',
 				7200, 9001, 9001,
 				TimeValue::PRECISION_YEAR1G,
 				'http://nyan.cat/original.php'
 			),
 			'Minimum timezone' => array(
-				'+2013-01-01T00:00:00Z',
+				'+2013-00-00T00:00:00Z',
 				-7200, 0, 42,
 				TimeValue::PRECISION_YEAR,
 				'http://nyan.cat/original.php'
@@ -54,7 +54,7 @@ class TimeValueTest extends DataValueTest {
 				'http://nyan.cat/original.php'
 			),
 			'No day' => array(
-				'+2015-01-00T00:00:00Z',
+				'+2015-00-00T00:00:00Z',
 				0, 0, 0,
 				TimeValue::PRECISION_YEAR,
 				'http://nyan.cat/original.php'
@@ -261,27 +261,33 @@ class TimeValueTest extends DataValueTest {
 	}
 
 	/**
-	 * @dataProvider unpaddedYearsProvider
+	 * @dataProvider notNormalizedTimestampProvider
 	 */
-	public function testGivenUnpaddedYear_yearIsPadded( $year, $expected ) {
+	public function testTimestampNormalization( $input, $expected, $precision ) {
 		$timeValue = new TimeValue(
-			$year . '-01-01T00:00:00Z',
+			$input,
 			0, 0, 0,
-			TimeValue::PRECISION_DAY,
+			$precision,
 			'Stardate'
 		);
-		$this->assertSame( $expected . '-01-01T00:00:00Z', $timeValue->getTime() );
+		$this->assertSame( $expected, $timeValue->getTime() );
 	}
 
-	public function unpaddedYearsProvider() {
+	public function notNormalizedTimestampProvider() {
 		return array(
-			array( '+1', '+0001' ),
-			array( '-10', '-0010' ),
-			array( '+2015', '+2015' ),
-			array( '+02015', '+2015' ),
-			array( '+00000010000', '+10000' ),
-			array( '+0000000000000001', '+0001' ),
-			array( '+9999999999999999', '+9999999999999999' ),
+			array( '+1-00-00T00:00:00Z', '+0001-00-00T00:00:00Z', TimeValue::PRECISION_YEAR ),
+			array( '-10-00-00T00:00:00Z', '-0010-00-00T00:00:00Z', TimeValue::PRECISION_YEAR ),
+			array( '+2015-00-00T00:00:00Z', '+2015-00-00T00:00:00Z', TimeValue::PRECISION_YEAR ),
+			array( '+02015-00-00T00:00:00Z', '+2015-00-00T00:00:00Z', TimeValue::PRECISION_YEAR ),
+			array( '+00000010000-00-00T00:00:00Z', '+10000-00-00T00:00:00Z', TimeValue::PRECISION_YEAR ),
+			array( '+0000000000000001-00-00T00:00:00Z', '+0001-00-00T00:00:00Z', TimeValue::PRECISION_YEAR ),
+			array( '+9999999999999999-00-00T00:00:00Z', '+9999999999999999-00-00T00:00:00Z', TimeValue::PRECISION_YEAR ),
+			array( '+2015-01-01T01:01:01Z', '+2015-00-00T00:00:00Z', TimeValue::PRECISION_YEAR ),
+			array( '+2015-01-01T01:01:01Z', '+2015-01-00T00:00:00Z', TimeValue::PRECISION_MONTH ),
+			array( '+2015-01-01T01:01:01Z', '+2015-01-01T00:00:00Z', TimeValue::PRECISION_DAY ),
+			array( '+2015-01-01T01:01:01Z', '+2015-01-01T01:00:00Z', TimeValue::PRECISION_HOUR ),
+			array( '+2015-01-01T01:01:01Z', '+2015-01-01T01:01:00Z', TimeValue::PRECISION_MINUTE ),
+			array( '+2015-01-01T01:01:01Z', '+2015-01-01T01:01:01Z', TimeValue::PRECISION_SECOND ),
 		);
 	}
 

--- a/tests/ValueFormatters/TimeFormatterTest.php
+++ b/tests/ValueFormatters/TimeFormatterTest.php
@@ -69,16 +69,16 @@ class TimeFormatterTest extends ValueFormatterTestBase {
 			),
 
 			// Different precisions
-			'+2013-07-17T00:00:00Z' => array(
-				'+2013-07-17T00:00:00Z',
+			'+2013-07-00T00:00:00Z' => array(
+				'+2013-07-00T00:00:00Z',
 				TimeValue::PRECISION_MONTH,
 			),
-			'+2013-07-18T00:00:00Z' => array(
-				'+2013-07-18T00:00:00Z',
+			'+2013-00-00T00:00:00Z' => array(
+				'+2013-00-00T00:00:00Z',
 				TimeValue::PRECISION_YEAR,
 			),
-			'+2013-07-19T00:00:00Z' => array(
-				'+2013-07-19T00:00:00Z',
+			'+2013-00-00T00:00:00Z' => array(
+				'+2013-00-00T00:00:00Z',
 				TimeValue::PRECISION_YEAR10,
 			),
 		);


### PR DESCRIPTION
E.g. Set the month to "00" if the precision is year or lower...

Allows to do string comparison in order to compare timestamps without having to truncate the timestamp to the precision