### PR TITLE
Fix format name strings in parsers

### DIFF
--- a/src/ValueParsers/IsoTimestampParser.php
+++ b/src/ValueParsers/IsoTimestampParser.php
@@ -25,7 +25,7 @@ use InvalidArgumentException;
  */
 class IsoTimestampParser extends StringValueParser {
 
-	const FORMAT_NAME = 'time';
+	const FORMAT_NAME = 'iso-timestamp';
 
 	const OPT_PRECISION = 'precision';
 	const OPT_CALENDAR = 'calendar';

--- a/src/ValueParsers/PhpDateTimeParser.php
+++ b/src/ValueParsers/PhpDateTimeParser.php
@@ -29,7 +29,7 @@ use Exception;
  */
 class PhpDateTimeParser extends StringValueParser {
 
-	const FORMAT_NAME = 'datetime';
+	const FORMAT_NAME = 'php-date-time';
 
 	/**
 	 * @var MonthNameUnlocalizer

--- a/src/ValueParsers/YearMonthDayTimeParser.php
+++ b/src/ValueParsers/YearMonthDayTimeParser.php
@@ -16,7 +16,7 @@ use DataValues\TimeValue;
  */
 class YearMonthDayTimeParser extends StringValueParser {
 
-	const FORMAT_NAME = 'datetime';
+	const FORMAT_NAME = 'year-month-day';
 
 	/**
 	 * @var ValueParser


### PR DESCRIPTION
As far as I can tell this is **not** a breaking change. These constants are not used anywhere except for exception messages. There was quite some confusion about these constants when we introduced new parsers and renamed existing parser classes. With this patch I'm applying the most simple naming scheme: identical to the relevant part of the class name, lowercase, separated with dashes.

Please merge https://github.com/DataValues/Geo/pull/56 and https://gerrit.wikimedia.org/r/257592 along with this.