### PR TITLE
Add MonthNameProvider and MonolingualMonthNameProvider

### DIFF
--- a/src/ValueParsers/MonolingualMonthNameProvider.php
+++ b/src/ValueParsers/MonolingualMonthNameProvider.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace ValueParsers;
+
+/**
+ * A monolingual month name and month number provider, based on a static array.
+ *
+ * @since 0.8.4
+ *
+ * @license GPL-2.0+
+ * @author Thiemo Mättig
+ */
+class MonolingualMonthNameProvider implements MonthNameProvider {
+
+	/**
+	 * @var string[]
+	 */
+	private $monthNames;
+
+	/**
+	 * @param string[] $monthNames Array mapping month numbers (1 to 12) to localized month names.
+	 */
+	function __construct( array $monthNames ) {
+		$this->monthNames = $monthNames;
+	}
+
+	/**
+	 * @param string $languageCode Ignored in this implementation.
+	 *
+	 * @return string[] Array mapping month numbers (1 to 12) to localized month names.
+	 */
+	public function getLocalizedMonthNames( $languageCode ) {
+		return $this->monthNames;
+	}
+
+	/**
+	 * @param string $languageCode Ignored in this implementation.
+	 *
+	 * @return int[] Array mapping localized month names to month numbers (1 to 12).
+	 */
+	public function getMonthNumbers( $languageCode ) {
+		return array_flip( $this->monthNames );
+	}
+
+}

--- a/src/ValueParsers/MonthNameProvider.php
+++ b/src/ValueParsers/MonthNameProvider.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace ValueParsers;
+
+/**
+ * A common interface for both localizing month names in formatters as well as unlocalizing month
+ * names in parsers.
+ *
+ * @since 0.8.4
+ *
+ * @license GPL-2.0+
+ * @author Thiemo Mättig
+ */
+interface MonthNameProvider {
+
+	/**
+	 * @param string $languageCode
+	 *
+	 * @return string[] Array mapping month numbers (1 to 12) to localized month names.
+	 */
+	public function getLocalizedMonthNames( $languageCode );
+
+	/**
+	 * @param string $languageCode
+	 *
+	 * @return int[] Array mapping localized month names (possibly including full month names,
+	 * genitive names and abbreviations) to month numbers (1 to 12).
+	 */
+	public function getMonthNumbers( $languageCode );
+
+}

--- a/tests/ValueParsers/MonolingualMonthNameProviderTest.php
+++ b/tests/ValueParsers/MonolingualMonthNameProviderTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace ValueParsers\Test;
+
+use PHPUnit_Framework_TestCase;
+use ValueParsers\MonolingualMonthNameProvider;
+
+/**
+ * @covers ValueParsers\MonolingualMonthNameProvider
+ *
+ * @group DataValue
+ * @group DataValueExtensions
+ * @group ValueParsers
+ *
+ * @license GPL-2.0+
+ * @author Thiemo Mättig
+ */
+class MonolingualMonthNameProviderTest extends PHPUnit_Framework_TestCase {
+
+	public function testGetLocalizedMonthNames() {
+		$instance = new MonolingualMonthNameProvider( array( 1 => 'January' ) );
+		$this->assertSame( array( 1 => 'January' ), $instance->getLocalizedMonthNames( 'xx' ) );
+	}
+
+	public function testGetMonthNumbers() {
+		$instance = new MonolingualMonthNameProvider( array( 1 => 'January' ) );
+		$this->assertSame( array( 'January' => 1 ), $instance->getMonthNumbers( 'xx' ) );
+	}
+
+}


### PR DESCRIPTION
Moved from the repo directory from Wikibase.git. The interface will be used in multiple parsers. The static implementation is mostly for tests, but I did not wanted to have this as a private detail in the tests folder because I want to use this in repo tests too.