### PR TITLE
Fix IsoTimestamp/YearMonthDayTimeParser not accepting precisions

### DIFF
--- a/src/ValueParsers/IsoTimestampParser.php
+++ b/src/ValueParsers/IsoTimestampParser.php
@@ -163,12 +163,18 @@ class IsoTimestampParser extends StringValueParser {
 
 		$option = $this->getOption( self::OPT_PRECISION );
 
-		// It's impossible to increase the detected precision via option, e.g. from year to month if
-		// no month is given. If a day is given it can be increased, relevant for midnight.
-		if ( is_int( $option )
-			&& ( $option <= $precision || $precision >= TimeValue::PRECISION_DAY )
-		) {
-			return $option;
+		if ( $option !== null ) {
+			if ( !is_int( $option ) && !ctype_digit( $option ) ) {
+				throw new ParseException( 'Precision must be an integer' );
+			}
+
+			$option = (int)$option;
+
+			// It's impossible to increase the detected precision via option, e.g. from year to month if
+			// no month is given. If a day is given it can be increased, relevant for midnight.
+			if ( $option <= $precision || $precision >= TimeValue::PRECISION_DAY ) {
+				return $option;
+			}
 		}
 
 		return $precision;

--- a/tests/ValueParsers/YearMonthDayTimeParserTest.php
+++ b/tests/ValueParsers/YearMonthDayTimeParserTest.php
@@ -3,6 +3,8 @@
 namespace ValueParsers\Test;
 
 use DataValues\TimeValue;
+use ValueParsers\IsoTimestampParser;
+use ValueParsers\ParserOptions;
 use ValueParsers\YearMonthDayTimeParser;
 
 /**
@@ -186,6 +188,101 @@ class YearMonthDayTimeParserTest extends StringValueParserTest {
 		}
 
 		return $cases;
+	}
+
+	/**
+	 * @dataProvider optionsProvider
+	 */
+	public function testOptions(
+		$value,
+		array $options,
+		$timestamp,
+		$calendarModel,
+		$precision = TimeValue::PRECISION_DAY
+	) {
+		$parser = new YearMonthDayTimeParser( null, new ParserOptions( $options ) );
+		$this->assertEquals(
+			new TimeValue( $timestamp, 0, 0, 0, $precision, $calendarModel ),
+			$parser->parse( $value )
+		);
+	}
+
+	public function optionsProvider() {
+		$gregorian = 'http://www.wikidata.org/entity/Q1985727';
+		$julian = 'http://www.wikidata.org/entity/Q1985786';
+
+		return array(
+			'Auto-detected Gregorian' => array(
+				'1583-01-31',
+				array(),
+				'+1583-01-31T00:00:00Z',
+				$gregorian
+			),
+			'Option overrides auto-detected Gregorian' => array(
+				'1583-01-31',
+				array( IsoTimestampParser::OPT_CALENDAR => $julian ),
+				'+1583-01-31T00:00:00Z',
+				$julian
+			),
+			'Auto-detected Julian' => array(
+				'1582-01-31',
+				array(),
+				'+1582-01-31T00:00:00Z',
+				$julian
+			),
+			'Option overrides auto-detected Julian' => array(
+				'1582-01-31',
+				array( IsoTimestampParser::OPT_CALENDAR => $gregorian ),
+				'+1582-01-31T00:00:00Z',
+				$gregorian
+			),
+			'Option can decrease precision' => array(
+				'2016-01-31',
+				array( IsoTimestampParser::OPT_PRECISION => TimeValue::PRECISION_MONTH ),
+				'+2016-01-31T00:00:00Z',
+				$gregorian,
+				TimeValue::PRECISION_MONTH
+			),
+			'Option can set minimal precision' => array(
+				'2016-01-31',
+				array( IsoTimestampParser::OPT_PRECISION => TimeValue::PRECISION_YEAR1G ),
+				'+2016-01-31T00:00:00Z',
+				$gregorian,
+				TimeValue::PRECISION_YEAR1G
+			),
+			'Option can increase day precision' => array(
+				'2016-01-31',
+				array( IsoTimestampParser::OPT_PRECISION => TimeValue::PRECISION_HOUR ),
+				'+2016-01-31T00:00:00Z',
+				$gregorian,
+				TimeValue::PRECISION_HOUR
+			),
+			'Precision option accepts strings' => array(
+				'2016-01-31',
+				array( IsoTimestampParser::OPT_PRECISION => '10' ),
+				'+2016-01-31T00:00:00Z',
+				$gregorian,
+				TimeValue::PRECISION_MONTH
+			),
+		);
+	}
+
+	/**
+	 * @dataProvider invalidOptionsProvider
+	 */
+	public function testInvalidOptions( array $options ) {
+		$parser = new YearMonthDayTimeParser( null, new ParserOptions( $options ) );
+		$this->setExpectedException( 'ValueParsers\ParseException' );
+		$parser->parse( '2016-01-31' );
+	}
+
+	public function invalidOptionsProvider() {
+		return array(
+			array( array( IsoTimestampParser::OPT_PRECISION => -1 ) ),
+			array( array( IsoTimestampParser::OPT_PRECISION => 1.5 ) ),
+			array( array( IsoTimestampParser::OPT_PRECISION => 1000 ) ),
+			array( array( IsoTimestampParser::OPT_PRECISION => 'invalid' ) ),
+		);
 	}
 
 }


### PR DESCRIPTION
This patch fixes multiple bugs:
* YearMonthDayTimeParser did not accepted any option. Not it forwards to IsoTimestampParser and uses it's calendar model and precision detection.
* When you set the precision option in the API, it's a string, not an integer. This was not accepted.
* When you used an invalid precision, this was sometimes silently ignored, but should throw an exception.

[Bug: T128783](https://phabricator.wikimedia.org/T128783)