### PR TITLE
Release 0.8.4 with Year(Month)TimeParsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ DataValues Time has been written by the Wikidata team, as [Wikimedia Germany]
 
 ## Release notes
 
+### 0.8.4 (2016-04-14)
+
+* Added `MonthNameProvider` interface.
+* Added `MonolingualMonthNameProvider`.
+* Added `YearMonthTimeParser`.
+* Added `YearTimeParser`.
+
 ### 0.8.3 (2016-03-16)
 
 * Added optional `ParserOptions` parameter to the `YearMonthDayTimeParser` constructor.

--- a/Time.php
+++ b/Time.php
@@ -15,7 +15,7 @@ if ( defined( 'DATAVALUES_TIME_VERSION' ) ) {
 	return 1;
 }
 
-define( 'DATAVALUES_TIME_VERSION', '0.8.3' );
+define( 'DATAVALUES_TIME_VERSION', '0.8.4' );
 
 if ( defined( 'MEDIAWIKI' ) ) {
 	$GLOBALS['wgExtensionCredits']['datavalues'][] = array(

--- a/src/ValueParsers/YearMonthTimeParser.php
+++ b/src/ValueParsers/YearMonthTimeParser.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace ValueParsers;
+
+use DataValues\TimeValue;
+
+/**
+ * @since 0.8.4
+ *
+ * @license GPL-2.0+
+ * @author Addshore
+ * @author Thiemo Mättig
+ *
+ * @todo match BCE dates in here
+ */
+class YearMonthTimeParser extends StringValueParser {
+
+	const FORMAT_NAME = 'year-month';
+
+	/**
+	 * @var int[] Array mapping localized month names to month numbers (1 to 12).
+	 */
+	private $monthNumbers;
+
+	/**
+	 * @var ValueParser
+	 */
+	private $isoTimestampParser;
+
+	/**
+	 * @see StringValueParser::__construct
+	 *
+	 * @param MonthNameProvider $monthNameProvider
+	 * @param ParserOptions|null $options
+	 */
+	public function __construct(
+		MonthNameProvider $monthNameProvider,
+		ParserOptions $options = null
+	) {
+		parent::__construct( $options );
+
+		$languageCode = $this->getOption( ValueParser::OPT_LANG );
+		$this->monthNumbers = $monthNameProvider->getMonthNumbers( $languageCode );
+		$this->isoTimestampParser = new IsoTimestampParser(
+			new CalendarModelParser( $this->options ),
+			$this->options
+		);
+	}
+
+	/**
+	 * Parses the provided string and returns the result.
+	 *
+	 * @param string $value
+	 *
+	 * @throws ParseException
+	 * @return TimeValue
+	 */
+	protected function stringParse( $value ) {
+		//Matches Year and month separated by a separator, \p{L} matches letters outside the ASCII range
+		if ( !preg_match( '/^([\d\p{L}]+)\s*[\/\-\s.,]\s*([\d\p{L}]+)$/', trim( $value ), $matches ) ) {
+			throw new ParseException( 'Failed to parse year and month', $value, self::FORMAT_NAME );
+		}
+		list( , $a, $b ) = $matches;
+
+		$aIsInt = preg_match( '/^\d+$/', $a );
+		$bIsInt = preg_match( '/^\d+$/', $b );
+
+		if ( $aIsInt && $bIsInt ) {
+			$parsed = $this->parseYearMonthTwoInts( $a, $b );
+			if ( $parsed ) {
+				return $parsed;
+			}
+		}
+
+		if ( $aIsInt || $bIsInt ) {
+			if ( $aIsInt ) {
+				$year = $a;
+				$month = trim( $b );
+			} else {
+				$year = $b;
+				$month = trim( $a );
+			}
+
+			$parsed = $this->parseYearMonth( $year, $month );
+			if ( $parsed ) {
+				return $parsed;
+			}
+		}
+
+		throw new ParseException( 'Failed to parse year and month', $value, self::FORMAT_NAME );
+	}
+
+	/**
+	 * If we have 2 integers parse the date assuming that the larger is the year
+	 * unless the smaller is not a 'legal' month value
+	 *
+	 * @param string|int $a
+	 * @param string|int $b
+	 *
+	 * @return TimeValue|bool
+	 */
+	private function parseYearMonthTwoInts( $a, $b ) {
+		if ( !preg_match( '/^\d+$/', $a ) || !preg_match( '/^\d+$/', $b ) ) {
+			return false;
+		}
+
+		if ( !$this->canBeMonth( $a ) && $this->canBeMonth( $b ) ) {
+			return $this->getTimeFromYearMonth( $a, $b );
+		} elseif ( $this->canBeMonth( $a ) ) {
+			return $this->getTimeFromYearMonth( $b, $a );
+		}
+
+		return false;
+	}
+
+	/**
+	 * If we have 1 int and 1 string then try to parse the int as the year and month as the string
+	 * Check for both the full name and abbreviations
+	 *
+	 * @param string|int $year
+	 * @param string $month
+	 *
+	 * @return TimeValue|bool
+	 */
+	private function parseYearMonth( $year, $month ) {
+		foreach ( $this->monthNumbers as $monthName => $i ) {
+			if ( strcasecmp( $monthName, $month ) === 0 ) {
+				return $this->getTimeFromYearMonth( $year, $i );
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * @param string $year
+	 * @param string $month
+	 *
+	 * @return TimeValue
+	 */
+	private function getTimeFromYearMonth( $year, $month ) {
+		return $this->isoTimestampParser->parse( sprintf( '+%d-%02d-00T00:00:00Z', $year, $month ) );
+	}
+
+	/**
+	 * @param string|int $value
+	 *
+	 * @return bool can the given value be a month?
+	 */
+	private function canBeMonth( $value ) {
+		return $value >= 0 && $value <= 12;
+	}
+
+}

--- a/src/ValueParsers/YearTimeParser.php
+++ b/src/ValueParsers/YearTimeParser.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace ValueParsers;
+
+use DataValues\TimeValue;
+
+/**
+ * A straight parser that accepts various strings representing a year, and only a year. Accepts
+ * years before common era as well as optional thousands separators. Should be called after
+ * YearMonthTimeParser when you want to accept both formats, because strings like "1 999" may either
+ * represent a month and a year or a year with digit grouping.
+ *
+ * @since 0.8.4
+ *
+ * @license GPL-2.0+
+ * @author Addshore
+ * @author Thiemo Mättig
+ */
+class YearTimeParser extends StringValueParser {
+
+	const FORMAT_NAME = 'year';
+
+	/**
+	 * Option to allow parsing of years with localized digit group separators. For example, the
+	 * English year -10,000 (with a comma) is written as -10.000 (with a dot) in German.
+	 */
+	const OPT_DIGIT_GROUP_SEPARATOR = 'digitGroupSeparator';
+
+	/**
+	 * Default, canonical digit group separator, as in the year -10,000.
+	 */
+	const CANONICAL_DIGIT_GROUP_SEPARATOR = ',';
+
+	/**
+	 * @var ValueParser
+	 */
+	private $eraParser;
+
+	/**
+	 * @var ValueParser
+	 */
+	private $isoTimestampParser;
+
+	/**
+	 * @param ValueParser|null $eraParser
+	 * @param ParserOptions|null $options
+	 */
+	public function __construct( ValueParser $eraParser = null, ParserOptions $options = null ) {
+		parent::__construct( $options );
+
+		$this->defaultOption(
+			self::OPT_DIGIT_GROUP_SEPARATOR,
+			self::CANONICAL_DIGIT_GROUP_SEPARATOR
+		);
+
+		$this->eraParser = $eraParser ?: new EraParser( $this->options );
+		$this->isoTimestampParser = new IsoTimestampParser(
+			new CalendarModelParser( $this->options ),
+			$this->options
+		);
+	}
+
+	/**
+	 * Parses the provided string and returns the result.
+	 *
+	 * @param string $value
+	 *
+	 * @throws ParseException
+	 * @return TimeValue
+	 */
+	protected function stringParse( $value ) {
+		list( $sign, $year ) = $this->eraParser->parse( $value );
+
+		// Negative dates usually don't have a month, assume non-digits are thousands separators
+		if ( $sign === '-' ) {
+			$separator = $this->getOption( self::OPT_DIGIT_GROUP_SEPARATOR );
+			// Always accept ISO (e.g. "1 000 BC") as well as programming style (e.g. "-1_000")
+			$year = preg_replace(
+				'/(?<=\d)[' . preg_quote( $separator, '/' ) . '\s_](?=\d)/',
+				'',
+				$year
+			);
+		}
+
+		if ( !preg_match( '/^\d+$/', $year ) ) {
+			throw new ParseException( 'Failed to parse year', $value, self::FORMAT_NAME );
+		}
+
+		return $this->isoTimestampParser->parse( $sign . $year . '-00-00T00:00:00Z' );
+	}
+
+}

--- a/tests/ValueParsers/YearMonthTimeParserTest.php
+++ b/tests/ValueParsers/YearMonthTimeParserTest.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace ValueParsers\Test;
+
+use DataValues\TimeValue;
+use ValueParsers\MonthNameProvider;
+use ValueParsers\YearMonthTimeParser;
+
+/**
+ * @covers ValueParsers\YearMonthTimeParser
+ *
+ * @group DataValue
+ * @group DataValueExtensions
+ * @group TimeParsers
+ * @group ValueParsers
+ *
+ * @license GPL-2.0+
+ * @author Addshore
+ * @author Thiemo Mättig
+ */
+class YearMonthTimeParserTest extends StringValueParserTest {
+
+	/**
+	 * @deprecated since 0.3, just use getInstance.
+	 */
+	protected function getParserClass() {
+		throw new \LogicException( 'Should not be called, use getInstance' );
+	}
+
+	/**
+	 * @see ValueParserTestBase::getInstance
+	 *
+	 * @return YearMonthTimeParser
+	 */
+	protected function getInstance() {
+		$monthNameProvider = $this->getMockBuilder( 'ValueParsers\MonthNameProvider' )
+			->disableOriginalConstructor()
+			->getMock();
+		$monthNameProvider->expects( $this->once() )
+			->method( 'getMonthNumbers' )
+			->with( 'en' )
+			->will( $this->returnValue( array(
+				'January' => 1,
+				'Jan' => 1,
+				'April' => 4,
+			) ) );
+
+		return new YearMonthTimeParser( $monthNameProvider );
+	}
+
+	/**
+	 * @see ValueParserTestBase::validInputProvider
+	 */
+	public function validInputProvider() {
+		$gregorian = 'http://www.wikidata.org/entity/Q1985727';
+		$julian = 'http://www.wikidata.org/entity/Q1985786';
+
+		$argLists = array();
+
+		$valid = array(
+			// leading zeros
+			'00001 1999' =>
+				array( '+1999-01-00T00:00:00Z' ),
+			'000000001 100001999' =>
+				array( '+100001999-01-00T00:00:00Z' ),
+
+			// use string month names
+			'Jan/1999' =>
+				array( '+1999-01-00T00:00:00Z' ),
+			'January/1999' =>
+				array( '+1999-01-00T00:00:00Z' ),
+			'January/1' =>
+				array( '+0001-01-00T00:00:00Z', TimeValue::PRECISION_MONTH, $julian ),
+			'1999 January' =>
+				array( '+1999-01-00T00:00:00Z' ),
+			'January 1999' =>
+				array( '+1999-01-00T00:00:00Z' ),
+			'January-1' =>
+				array( '+0001-01-00T00:00:00Z', TimeValue::PRECISION_MONTH, $julian ),
+			'JanuARY-1' =>
+				array( '+0001-01-00T00:00:00Z', TimeValue::PRECISION_MONTH, $julian ),
+			'JaN/1999' =>
+				array( '+1999-01-00T00:00:00Z' ),
+			'januARY-1' =>
+				array( '+0001-01-00T00:00:00Z', TimeValue::PRECISION_MONTH, $julian ),
+			'jan/1999' =>
+				array( '+1999-01-00T00:00:00Z' ),
+
+			// use different date separators
+			'1-1999' =>
+				array( '+1999-01-00T00:00:00Z' ),
+			'1/1999' =>
+				array( '+1999-01-00T00:00:00Z' ),
+			'1 / 1999' =>
+				array( '+1999-01-00T00:00:00Z' ),
+			'1 1999' =>
+				array( '+1999-01-00T00:00:00Z' ),
+			'1,1999' =>
+				array( '+1999-01-00T00:00:00Z' ),
+			'1.1999' =>
+				array( '+1999-01-00T00:00:00Z' ),
+			'1. 1999' =>
+				array( '+1999-01-00T00:00:00Z' ),
+
+			// presume mm/yy unless impossible month, in which case switch
+			'12/12' =>
+				array( '+0012-12-00T00:00:00Z', TimeValue::PRECISION_MONTH, $julian ),
+			'12/11' =>
+				array( '+0011-12-00T00:00:00Z', TimeValue::PRECISION_MONTH, $julian ),
+			'11/12' =>
+				array( '+0012-11-00T00:00:00Z', TimeValue::PRECISION_MONTH, $julian ),
+			'13/12' =>
+				array( '+0013-12-00T00:00:00Z', TimeValue::PRECISION_MONTH, $julian ),
+			'12/13' =>
+				array( '+0013-12-00T00:00:00Z', TimeValue::PRECISION_MONTH, $julian ),
+			'2000 1' =>
+				array( '+2000-01-00T00:00:00Z' ),
+
+			// big years
+			'April-1000000001' =>
+				array( '+1000000001-04-00T00:00:00Z' ),
+			'April 1000000001' =>
+				array( '+1000000001-04-00T00:00:00Z' ),
+			'1000000001 April' =>
+				array( '+1000000001-04-00T00:00:00Z' ),
+			'1 13000' =>
+				array( '+13000-01-00T00:00:00Z' ),
+
+			// parse 0 month as if no month has been entered
+			'0.1999' =>
+				array( '+1999-00-00T00:00:00Z', TimeValue::PRECISION_YEAR ),
+			'1999 0' =>
+				array( '+1999-00-00T00:00:00Z', TimeValue::PRECISION_YEAR ),
+		);
+
+		foreach ( $valid as $value => $expected ) {
+			$timestamp = $expected[0];
+			$precision = isset( $expected[1] ) ? $expected[1] : TimeValue::PRECISION_MONTH;
+			$calendarModel = isset( $expected[2] ) ? $expected[2] : $gregorian;
+
+			$argLists[] = array(
+				(string)$value,
+				new TimeValue( $timestamp, 0, 0, 0, $precision, $calendarModel )
+			);
+		}
+
+		return $argLists;
+	}
+
+	/**
+	 * @see StringValueParserTest::invalidInputProvider
+	 */
+	public function invalidInputProvider() {
+		$argLists = parent::invalidInputProvider();
+
+		$invalid = array(
+			//These are just wrong!
+			'June June June',
+			'111 111 111',
+			'Jann 2014',
+			'13/13',
+			'13,1999',
+			'1999,13',
+
+			//Dont parse stuff with separators in the year
+			'june 200,000,000',
+			'june 200.000.000',
+
+			//Not within the scope of this parser
+			'1 July 20000',
+			'20000',
+		);
+
+		foreach ( $invalid as $value ) {
+			$argLists[] = array( $value );
+		}
+
+		return $argLists;
+	}
+
+}

--- a/tests/ValueParsers/YearTimeParserTest.php
+++ b/tests/ValueParsers/YearTimeParserTest.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace ValueParsers\Test;
+
+use DataValues\TimeValue;
+use ValueParsers\EraParser;
+use ValueParsers\ParserOptions;
+use ValueParsers\YearTimeParser;
+
+/**
+ * @covers ValueParsers\YearTimeParser
+ *
+ * @group DataValue
+ * @group DataValueExtensions
+ * @group TimeParsers
+ * @group ValueParsers
+ *
+ * @license GPL-2.0+
+ * @author Addshore
+ * @author Thiemo Mättig
+ */
+class YearTimeParserTest extends StringValueParserTest {
+
+	/**
+	 * @deprecated since 0.3, just use getInstance.
+	 */
+	protected function getParserClass() {
+		throw new \LogicException( 'Should not be called, use getInstance' );
+	}
+
+	/**
+	 * @see ValueParserTestBase::getInstance
+	 *
+	 * @return YearTimeParser
+	 */
+	protected function getInstance() {
+		return new YearTimeParser( $this->getMockEraParser() );
+	}
+
+	/**
+	 * @return EraParser
+	 */
+	private function getMockEraParser() {
+		$mock = $this->getMockBuilder( 'ValueParsers\EraParser' )
+			->disableOriginalConstructor()
+			->getMock();
+		$mock->expects( $this->any() )
+			->method( 'parse' )
+			->with( $this->isType( 'string' ) )
+			->will( $this->returnCallback(
+				function( $value ) {
+					$sign = '+';
+					// Tiny parser that supports a single negative sign only
+					if ( $value[0] === '-' ) {
+						$sign = '-';
+						$value = substr( $value, 1 );
+					}
+					return array( $sign, $value );
+				}
+			) );
+		return $mock;
+	}
+
+	/**
+	 * @see ValueParserTestBase::validInputProvider
+	 */
+	public function validInputProvider() {
+		$gregorian = 'http://www.wikidata.org/entity/Q1985727';
+		$julian = 'http://www.wikidata.org/entity/Q1985786';
+
+		$argLists = array();
+
+		$valid = array(
+			'1999' =>
+				array( '+1999-00-00T00:00:00Z' ),
+			'2000' =>
+				array( '+2000-00-00T00:00:00Z' ),
+			'2010' =>
+				array( '+2010-00-00T00:00:00Z' ),
+			'2000000' =>
+				array( '+2000000-00-00T00:00:00Z', TimeValue::PRECISION_YEAR1M ),
+			'2000000000' =>
+				array( '+2000000000-00-00T00:00:00Z', TimeValue::PRECISION_YEAR1G ),
+			'2000020000' =>
+				array( '+2000020000-00-00T00:00:00Z', TimeValue::PRECISION_YEAR10K ),
+			'2000001' =>
+				array( '+2000001-00-00T00:00:00Z' ),
+			'02000001' =>
+				array( '+2000001-00-00T00:00:00Z' ),
+			'1' =>
+				array( '+0001-00-00T00:00:00Z', TimeValue::PRECISION_YEAR, $julian ),
+			'000000001' =>
+				array( '+0001-00-00T00:00:00Z', TimeValue::PRECISION_YEAR, $julian ),
+			'-1000000' =>
+				array( '-1000000-00-00T00:00:00Z', TimeValue::PRECISION_YEAR1M, $julian ),
+			'-1 000 000' =>
+				array( '-1000000-00-00T00:00:00Z', TimeValue::PRECISION_YEAR1M, $julian ),
+			'-19_000' =>
+				array( '-19000-00-00T00:00:00Z', TimeValue::PRECISION_YEAR1K, $julian ),
+			// Digit grouping in the Indian numbering system
+			'-1,99,999' =>
+				array( '-199999-00-00T00:00:00Z', TimeValue::PRECISION_YEAR, $julian ),
+		);
+
+		foreach ( $valid as $value => $expected ) {
+			$timestamp = $expected[0];
+			$precision = isset( $expected[1] ) ? $expected[1] : TimeValue::PRECISION_YEAR;
+			$calendarModel = isset( $expected[2] ) ? $expected[2] : $gregorian;
+
+			$argLists[] = array(
+				(string)$value,
+				new TimeValue( $timestamp, 0, 0, 0, $precision, $calendarModel )
+			);
+		}
+
+		return $argLists;
+	}
+
+	public function testDigitGroupSeparatorOption() {
+		$options = new ParserOptions();
+		$options->setOption( YearTimeParser::OPT_DIGIT_GROUP_SEPARATOR, '.' );
+		$parser = new YearTimeParser( null, $options );
+		$timeValue = $parser->parse( '-19.000' );
+		$this->assertSame( '-19000-00-00T00:00:00Z', $timeValue->getTime() );
+	}
+
+	/**
+	 * @see StringValueParserTest::invalidInputProvider
+	 */
+	public function invalidInputProvider() {
+		$argLists = parent::invalidInputProvider();
+
+		$invalid = array(
+			//These are just wrong!
+			'June June June',
+			'111 111 111',
+			'Jann 2014',
+
+			//Not within the scope of this parser
+			'1 July 20000',
+
+			//We should not try to parse these, this just gets confusing
+			'-100BC',
+			'+100BC',
+			'-100 BC',
+			'+100 BC',
+			'+100 BCE',
+			'+100BCE',
+
+			// Non-default and invalid thousands separators
+			'-,999',
+			'-999,',
+			'-19.000',
+			'-1/000/000',
+
+			// Positive years are unlikely to have thousands separators, it's more likely a date
+			'1 000 000',
+			'19_000',
+			'1,99,999',
+		);
+
+		foreach ( $invalid as $value ) {
+			$argLists[] = array( $value );
+		}
+
+		return $argLists;
+	}
+
+	/**
+	 * @expectedException \ValueParsers\ParseException
+	 * @expectedExceptionMessage Failed to parse year
+	 */
+	public function testParseExceptionMessage() {
+		$parser = $this->getInstance();
+		$parser->parse( 'ju5t 1nval1d' );
+	}
+
+}


### PR DESCRIPTION
The two "new" parsers are moved over here from Wikibase.git, which became possible after #105. I avoided changing any detail in the code of these classes. This is a pure move, only namespaces, imports and PHPDoc tags are changed. I know that these classes need more love (note the todo) and I will continue working on them.

[Bug: T132441](https://phabricator.wikimedia.org/T132441)