### PR TITLE
Avoid duplicate CalendarModelParser initialization code

### DIFF
--- a/src/ValueParsers/YearMonthTimeParser.php
+++ b/src/ValueParsers/YearMonthTimeParser.php
@@ -41,10 +41,7 @@ class YearMonthTimeParser extends StringValueParser {
 
 		$languageCode = $this->getOption( ValueParser::OPT_LANG );
 		$this->monthNumbers = $monthNameProvider->getMonthNumbers( $languageCode );
-		$this->isoTimestampParser = new IsoTimestampParser(
-			new CalendarModelParser( $this->options ),
-			$this->options
-		);
+		$this->isoTimestampParser = new IsoTimestampParser( null, $this->options );
 	}
 
 	/**

--- a/src/ValueParsers/YearTimeParser.php
+++ b/src/ValueParsers/YearTimeParser.php
@@ -54,10 +54,7 @@ class YearTimeParser extends StringValueParser {
 		);
 
 		$this->eraParser = $eraParser ?: new EraParser( $this->options );
-		$this->isoTimestampParser = new IsoTimestampParser(
-			new CalendarModelParser( $this->options ),
-			$this->options
-		);
+		$this->isoTimestampParser = new IsoTimestampParser( null, $this->options );
 	}
 
 	/**

--- a/tests/ValueParsers/IsoTimestampParserTest.php
+++ b/tests/ValueParsers/IsoTimestampParserTest.php
@@ -3,7 +3,6 @@
 namespace ValueParsers\Test;
 
 use DataValues\TimeValue;
-use ValueParsers\CalendarModelParser;
 use ValueParsers\IsoTimestampParser;
 use ValueParsers\ParserOptions;
 
@@ -356,7 +355,7 @@ class IsoTimestampParserTest extends ValueParserTestBase {
 				// Because PHP magically turns numeric keys into ints/floats
 				(string)$key,
 				new TimeValue( $timestamp, 0, 0, 0, $precision, $calendarModel ),
-				new IsoTimestampParser( new CalendarModelParser( $options ), $options )
+				new IsoTimestampParser( null, $options )
 			);
 		}
 

--- a/tests/ValueParsers/PhpDateTimeParserTest.php
+++ b/tests/ValueParsers/PhpDateTimeParserTest.php
@@ -3,7 +3,6 @@
 namespace ValueParsers\Test;
 
 use DataValues\TimeValue;
-use ValueParsers\CalendarModelParser;
 use ValueParsers\IsoTimestampParser;
 use ValueParsers\MonthNameUnlocalizer;
 use ValueParsers\ParserOptions;
@@ -42,7 +41,7 @@ class PhpDateTimeParserTest extends StringValueParserTest {
 		return new PhpDateTimeParser(
 			new MonthNameUnlocalizer( array() ),
 			$this->getEraParser(),
-			new IsoTimestampParser( new CalendarModelParser( $options ), $options )
+			new IsoTimestampParser( null, $options )
 		);
 	}
 


### PR DESCRIPTION
All this does is avoiding duplicate code.

[Bug: T132441](https://phabricator.wikimedia.org/T132441)