### PR TITLE
Test for newline injection vector in time parsers

### DIFF
--- a/src/ValueParsers/YearTimeParser.php
+++ b/src/ValueParsers/YearTimeParser.php
@@ -81,7 +81,7 @@ class YearTimeParser extends StringValueParser {
 			);
 		}
 
-		if ( !preg_match( '/^\d+$/', $year ) ) {
+		if ( !preg_match( '/^\d+\z/', $year ) ) {
 			throw new ParseException( 'Failed to parse year', $value, self::FORMAT_NAME );
 		}
 

--- a/tests/ValueParsers/YearMonthDayTimeParserTest.php
+++ b/tests/ValueParsers/YearMonthDayTimeParserTest.php
@@ -44,6 +44,10 @@ class YearMonthDayTimeParserTest extends StringValueParserTest {
 		$julian = 'http://www.wikidata.org/entity/Q1985786';
 
 		$valid = array(
+			// Whitespace
+			"2016-01-01\n" => array( '+2016-01-01T00:00:00Z' ),
+			' 2016-01-01 ' => array( '+2016-01-01T00:00:00Z' ),
+
 			// YMD, typically used in ISO 8601
 			'2015-12-31' => array( '+2015-12-31T00:00:00Z' ),
 			'2015 12 31' => array( '+2015-12-31T00:00:00Z' ),

--- a/tests/ValueParsers/YearMonthTimeParserTest.php
+++ b/tests/ValueParsers/YearMonthTimeParserTest.php
@@ -58,6 +58,12 @@ class YearMonthTimeParserTest extends StringValueParserTest {
 		$argLists = array();
 
 		$valid = array(
+			// Whitespace
+			"January 2016\n" =>
+				array( '+2016-01-00T00:00:00Z' ),
+			' January 2016 ' =>
+				array( '+2016-01-00T00:00:00Z' ),
+
 			// leading zeros
 			'00001 1999' =>
 				array( '+1999-01-00T00:00:00Z' ),

--- a/tests/ValueParsers/YearTimeParserTest.php
+++ b/tests/ValueParsers/YearTimeParserTest.php
@@ -131,6 +131,9 @@ class YearTimeParserTest extends StringValueParserTest {
 		$argLists = parent::invalidInputProvider();
 
 		$invalid = array(
+			// This should fail with an era parser that does no trimming
+			"2016\n",
+
 			//These are just wrong!
 			'June June June',
 			'111 111 111',


### PR DESCRIPTION
[Bug: T133299](https://phabricator.wikimedia.org/T133299)