### PR TITLE
Trim in YearTimeParser and add more whitespace tests

### DIFF
--- a/src/ValueParsers/YearTimeParser.php
+++ b/src/ValueParsers/YearTimeParser.php
@@ -69,6 +69,7 @@ class YearTimeParser extends StringValueParser {
 	 */
 	protected function stringParse( $value ) {
 		list( $sign, $year ) = $this->eraParser->parse( $value );
+		$year = trim( $year );
 
 		// Negative dates usually don't have a month, assume non-digits are thousands separators
 		if ( $sign === '-' ) {

--- a/tests/ValueParsers/IsoTimestampParserTest.php
+++ b/tests/ValueParsers/IsoTimestampParserTest.php
@@ -56,15 +56,17 @@ class IsoTimestampParserTest extends ValueParserTestBase {
 		$precSecondOpts->setOption( IsoTimestampParser::OPT_PRECISION, TimeValue::PRECISION_SECOND );
 
 		$valid = array(
-			// Empty options tests
-			'+0000000000002013-07-16T00:00:00Z' => array(
+			// Whitespace
+			"+0000000000002013-07-16T00:00:00Z\n" => array(
 				'+2013-07-16T00:00:00Z',
 				TimeValue::PRECISION_DAY,
 			),
-			'+0000000000002013-07-00T00:00:00Z' => array(
+			' +0000000000002013-07-00T00:00:00Z ' => array(
 				'+2013-07-00T00:00:00Z',
 				TimeValue::PRECISION_MONTH,
 			),
+
+			// Empty options tests
 			'+0000000000002013-00-00T00:00:00Z' => array(
 				'+2013-00-00T00:00:00Z',
 				TimeValue::PRECISION_YEAR,
@@ -104,26 +106,6 @@ class IsoTimestampParserTest extends ValueParserTestBase {
 			),
 			'+0000002000000000-00-00T00:00:00Z' => array(
 				'+2000000000-00-00T00:00:00Z',
-				TimeValue::PRECISION_YEAR1G,
-			),
-			'+0000020000000000-00-00T00:00:00Z' => array(
-				'+20000000000-00-00T00:00:00Z',
-				TimeValue::PRECISION_YEAR1G,
-			),
-			'+0000200000000000-00-00T00:00:00Z' => array(
-				'+200000000000-00-00T00:00:00Z',
-				TimeValue::PRECISION_YEAR1G,
-			),
-			'+0002000000000000-00-00T00:00:00Z' => array(
-				'+2000000000000-00-00T00:00:00Z',
-				TimeValue::PRECISION_YEAR1G,
-			),
-			'+0020000000000000-00-00T00:00:00Z' => array(
-				'+20000000000000-00-00T00:00:00Z',
-				TimeValue::PRECISION_YEAR1G,
-			),
-			'+0200000000000000-00-00T00:00:00Z' => array(
-				'+200000000000000-00-00T00:00:00Z',
 				TimeValue::PRECISION_YEAR1G,
 			),
 			'+2000000000000000-00-00T00:00:00Z' => array(

--- a/tests/ValueParsers/PhpDateTimeParserTest.php
+++ b/tests/ValueParsers/PhpDateTimeParserTest.php
@@ -78,11 +78,13 @@ class PhpDateTimeParserTest extends StringValueParserTest {
 		$argList = array();
 
 		$valid = array(
+			// Whitespace
+			"10/10/2010\n" =>
+				array( '+0000000000002010-10-10T00:00:00Z' ),
+			' 10.10.2010 ' =>
+				array( '+0000000000002010-10-10T00:00:00Z' ),
+
 			// Normal/easy dates
-			'10/10/2010' =>
-				array( '+0000000000002010-10-10T00:00:00Z' ),
-			'10.10.2010' =>
-				array( '+0000000000002010-10-10T00:00:00Z' ),
 			'  10.  10.  2010  ' =>
 				array( '+0000000000002010-10-10T00:00:00Z' ),
 			'10,10,2010' =>

--- a/tests/ValueParsers/YearTimeParserTest.php
+++ b/tests/ValueParsers/YearTimeParserTest.php
@@ -71,10 +71,12 @@ class YearTimeParserTest extends StringValueParserTest {
 		$argLists = array();
 
 		$valid = array(
-			'1999' =>
+			// Whitespace
+			"1999\n" =>
 				array( '+1999-00-00T00:00:00Z' ),
-			'2000' =>
+			' 2000 ' =>
 				array( '+2000-00-00T00:00:00Z' ),
+
 			'2010' =>
 				array( '+2010-00-00T00:00:00Z' ),
 			'2000000' =>
@@ -131,9 +133,6 @@ class YearTimeParserTest extends StringValueParserTest {
 		$argLists = parent::invalidInputProvider();
 
 		$invalid = array(
-			// This should fail with an era parser that does no trimming
-			"2016\n",
-
 			//These are just wrong!
 			'June June June',
 			'111 111 111',


### PR DESCRIPTION
The YearTimeParser test was introduced in #116 and described the current behavior of the parser. In this patch I'm changing this behavior and add trimming, as all other parsers already do.

I'm using existing tests to not make the test case collection to big and time consuming.

For the same reason I'm removing redundant test cases from IsoTimestampParserTest.