### PR TITLE
Add PHPCS

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,9 @@
 		"data-values/interfaces": "~0.2.0|~0.1.5",
 		"data-values/common": "~0.3.0|~0.2.0"
 	},
+	"require-dev": {
+		"mediawiki/mediawiki-codesniffer": "~0.5"
+	},
 	"autoload": {
 		"files" : [
 			"Time.php"
@@ -40,5 +43,10 @@
 		"branch-alias": {
 			"dev-master": "0.8.x-dev"
 		}
+	},
+	"scripts": {
+		"phpcs": [
+			"vendor/bin/phpcs src/* tests/* --standard=phpcs.xml -sp"
+		]
 	}
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<ruleset name="DataValuesTime">
+	<!-- See https://github.com/wikimedia/mediawiki-tools-codesniffer/blob/master/MediaWiki/ruleset.xml -->
+	<rule ref="vendor/mediawiki/mediawiki-codesniffer/MediaWiki">
+		<exclude name="Generic.Arrays.DisallowLongArraySyntax" />
+		<exclude name="Generic.NamingConventions.UpperCaseConstantName" />
+		<exclude name="MediaWiki.WhiteSpace.SpaceBeforeSingleLineComment" />
+		<exclude name="MediaWiki.WhiteSpace.SpaceyParenthesis" />
+	</rule>
+
+	<rule ref="Generic.Files.LineLength">
+		<properties>
+			<property name="lineLimit" value="114" />
+		</properties>
+	</rule>
+
+	<arg name="extensions" value="php" />
+</ruleset>

--- a/tests/ValueParsers/PhpDateTimeParserTest.php
+++ b/tests/ValueParsers/PhpDateTimeParserTest.php
@@ -62,7 +62,7 @@ class PhpDateTimeParserTest extends StringValueParserTest {
 						$sign = '-';
 						$value = substr( $value, 1 );
 					}
-					return array( $sign, $value ) ;
+					return array( $sign, $value );
 				}
 			) );
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -11,4 +11,4 @@ if ( !is_readable( __DIR__ . '/../vendor/autoload.php' ) ) {
 	die( 'You need to install this package with Composer before you can run the tests' );
 }
 
-require_once( __DIR__ . '/../vendor/autoload.php' );
+require_once __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
This is the most minimal patch I can think of to add PHPCS support to this component. I'm reusing the predefined MediaWiki rule set with no additional rules (for now).