### PR TITLE
Add type hints to TimeValue

### DIFF
--- a/src/DataValues/TimeValue.php
+++ b/src/DataValues/TimeValue.php
@@ -417,12 +417,12 @@ class TimeValue extends DataValueObject {
 	 *
 	 * @since 0.1
 	 *
-	 * @param mixed $data
+	 * @param array $data
 	 *
 	 * @return TimeValue
 	 * @throws IllegalValueException
 	 */
-	public static function newFromArray( $data ) {
+	public static function newFromArray( array $data ) {
 		self::requireArrayFields(
 			$data,
 			array( 'time', 'timezone', 'before', 'after', 'precision', 'calendarmodel' )


### PR DESCRIPTION
`newFromArray` is not in an interfaces, but assumed to be there when called from `DataValueDeserializer`. No other assumption is made about the parameter. Having the strict type hint is not different from the manual check-and-throw.
