### PR TITLE
Parse and refuse invalid calendar option

### DIFF
--- a/src/ValueParsers/IsoTimestampParser.php
+++ b/src/ValueParsers/IsoTimestampParser.php
@@ -222,9 +222,8 @@ class IsoTimestampParser extends StringValueParser {
 	 * Determines the calendar model. The calendar model is determined as follows:
 	 *
 	 * - if $timeParts[7] is set, use $this->calendarModelParser to parse it into a URI.
-	 * - otherwise, if $this->getOption( self::OPT_CALENDAR ) is not null, return
-	 *   self::CALENDAR_JULIAN if the option is self::CALENDAR_JULIAN, and self::CALENDAR_GREGORIAN
-	 *   otherwise.
+	 * - otherwise, if $this->getOption( self::OPT_CALENDAR ) is not null, use
+	 *   $this->calendarModelParser to parse it into a URI.
 	 * - otherwise, use self::CALENDAR_JULIAN for dates before 1583, and self::CALENDAR_GREGORIAN
 	 *   for later dates.
 	 *
@@ -243,15 +242,8 @@ class IsoTimestampParser extends StringValueParser {
 
 		$option = $this->getOption( self::OPT_CALENDAR );
 
-		// Use the calendar given in the option, if given
 		if ( $option !== null ) {
-			// The calendar model is an URI and URIs can't be case-insensitive
-			switch ( $option ) {
-				case TimeValue::CALENDAR_JULIAN:
-					return TimeValue::CALENDAR_JULIAN;
-				default:
-					return TimeValue::CALENDAR_GREGORIAN;
-			}
+			return $this->calendarModelParser->parse( $option );
 		}
 
 		// The Gregorian calendar was introduced in October 1582,

--- a/tests/ValueParsers/IsoTimestampParserTest.php
+++ b/tests/ValueParsers/IsoTimestampParserTest.php
@@ -43,6 +43,9 @@ class IsoTimestampParserTest extends ValueParserTestBase {
 		$julianOpts = new ParserOptions();
 		$julianOpts->setOption( IsoTimestampParser::OPT_CALENDAR, $julian );
 
+		$julianTextOpts = new ParserOptions();
+		$julianTextOpts->setOption( IsoTimestampParser::OPT_CALENDAR, 'Julian' );
+
 		$gregorianOpts = new ParserOptions();
 		$gregorianOpts->setOption( IsoTimestampParser::OPT_CALENDAR, $gregorian );
 
@@ -175,6 +178,12 @@ class IsoTimestampParserTest extends ValueParserTestBase {
 				TimeValue::PRECISION_DAY,
 				$julian,
 				$julianOpts,
+			),
+			'+2001-01-04T00:00:00Z' => array(
+				'+2001-01-04T00:00:00Z',
+				TimeValue::PRECISION_DAY,
+				$julian,
+				$julianTextOpts,
 			),
 			'-1-01-04T00:00:00Z' => array(
 				'-0001-01-04T00:00:00Z',
@@ -493,6 +502,7 @@ class IsoTimestampParserTest extends ValueParserTestBase {
 
 	public function invalidOptionsProvider() {
 		return array(
+			array( array( IsoTimestampParser::OPT_CALENDAR => 'invalid' ) ),
 			array( array( IsoTimestampParser::OPT_PRECISION => -1 ) ),
 			array( array( IsoTimestampParser::OPT_PRECISION => 1.5 ) ),
 			array( array( IsoTimestampParser::OPT_PRECISION => 1000 ) ),

--- a/tests/ValueParsers/YearMonthDayTimeParserTest.php
+++ b/tests/ValueParsers/YearMonthDayTimeParserTest.php
@@ -228,6 +228,12 @@ class YearMonthDayTimeParserTest extends StringValueParserTest {
 				'+1583-01-31T00:00:00Z',
 				$julian
 			),
+			'Plain text option overrides auto-detected Gregorian' => array(
+				'1583-01-31',
+				array( IsoTimestampParser::OPT_CALENDAR => 'Julian' ),
+				'+1583-01-31T00:00:00Z',
+				$julian
+			),
 			'Auto-detected Julian' => array(
 				'1582-01-31',
 				array(),
@@ -282,6 +288,7 @@ class YearMonthDayTimeParserTest extends StringValueParserTest {
 
 	public function invalidOptionsProvider() {
 		return array(
+			array( array( IsoTimestampParser::OPT_CALENDAR => 'invalid' ) ),
 			array( array( IsoTimestampParser::OPT_PRECISION => -1 ) ),
 			array( array( IsoTimestampParser::OPT_PRECISION => 1.5 ) ),
 			array( array( IsoTimestampParser::OPT_PRECISION => 1000 ) ),


### PR DESCRIPTION
I do classify this as a bug. An unknown calendar string should either be kept as it is (TimeValue happily stores any non-empty string, and the validators we have in place will reject everything that's not a Wikidata concept URI). Or it should be rejected if the relevant CalendarModelParser does not understand it (which is what this patch does). But unknown strings should never silently become the Gregorian URI.

You might think this is a breaking change because code that could never fail before now throws a ParseException. But note this was always possible and documented, see IsoTimestampParser::stringParse. The exception is just thrown for one more reason now.

[Bug: T141518](https://phabricator.wikimedia.org/T141518)