### PR TITLE
Never accept hour, minute or second with no day

### DIFF
--- a/src/DataValues/TimeValue.php
+++ b/src/DataValues/TimeValue.php
@@ -246,14 +246,20 @@ class TimeValue extends DataValueObject {
 			throw new IllegalValueException( 'Month out of allowed bounds' );
 		} elseif ( $day > 31 ) {
 			throw new IllegalValueException( 'Day out of allowed bounds' );
-		} elseif ( $day > 0 && $month < 1 ) {
-			throw new IllegalValueException( 'Can not have a day with no month' );
 		} elseif ( $hour > 23 ) {
 			throw new IllegalValueException( 'Hour out of allowed bounds' );
 		} elseif ( $minute > 59 ) {
 			throw new IllegalValueException( 'Minute out of allowed bounds' );
 		} elseif ( $second > 61 ) {
 			throw new IllegalValueException( 'Second out of allowed bounds' );
+		}
+
+		if ( $month < 1 && $day > 0 ) {
+			throw new IllegalValueException( 'Can not have a day with no month' );
+		}
+
+		if ( $day < 1 && ( $hour > 0 || $minute > 0 || $second > 0 ) ) {
+			throw new IllegalValueException( 'Can not have hour, minute or second with no day' );
 		}
 
 		// Warning, never cast the year to integer to not run into 32-bit integer overflows!

--- a/src/ValueParsers/IsoTimestampParser.php
+++ b/src/ValueParsers/IsoTimestampParser.php
@@ -128,10 +128,10 @@ class IsoTimestampParser extends StringValueParser {
 			&& $hour === ''
 		) {
 			throw new ParseException( 'Not enough information to decide if the format is YMD' );
-		} elseif ( $month > 12 ) {
+		}
+
+		if ( $month > 12 ) {
 			throw new ParseException( 'Month out of range' );
-		} elseif ( $day > 0 && $month < 1 ) {
-			throw new ParseException( 'Can not have a day with no month' );
 		} elseif ( $day > 31 ) {
 			throw new ParseException( 'Day out of range' );
 		} elseif ( $hour > 23 ) {
@@ -140,6 +140,14 @@ class IsoTimestampParser extends StringValueParser {
 			throw new ParseException( 'Minute out of range' );
 		} elseif ( $second > 61 ) {
 			throw new ParseException( 'Second out of range' );
+		}
+
+		if ( $month < 1 && $day > 0 ) {
+			throw new ParseException( 'Can not have a day with no month' );
+		}
+
+		if ( $day < 1 && ( $hour > 0 || $minute > 0 || $second > 0 ) ) {
+			throw new ParseException( 'Can not have hour, minute or second with no day' );
 		}
 
 		$sign = str_replace( "\xE2\x88\x92", '-', $sign );

--- a/tests/DataValues/TimeValueTest.php
+++ b/tests/DataValues/TimeValueTest.php
@@ -164,6 +164,24 @@ class TimeValueTest extends DataValueTest {
 				TimeValue::PRECISION_DAY,
 				'http://nyan.cat/original.php'
 			),
+			'No day but hour' => array(
+				'+2015-01-00T01:00:00Z',
+				0, 0, 0,
+				TimeValue::PRECISION_DAY,
+				'http://nyan.cat/original.php'
+			),
+			'No day but minute' => array(
+				'+2015-01-00T00:01:00Z',
+				0, 0, 0,
+				TimeValue::PRECISION_DAY,
+				'http://nyan.cat/original.php'
+			),
+			'No day but second' => array(
+				'+2015-01-00T00:00:01Z',
+				0, 0, 0,
+				TimeValue::PRECISION_DAY,
+				'http://nyan.cat/original.php'
+			),
 			'Month out of range' => array(
 				'+00000002013-13-01T00:00:00Z',
 				0, 0, 0,

--- a/tests/ValueParsers/IsoTimestampParserTest.php
+++ b/tests/ValueParsers/IsoTimestampParserTest.php
@@ -371,6 +371,9 @@ class IsoTimestampParserTest extends ValueParserTestBase {
 			'+2015-12-31T23Z',
 			// Elements out of allowed bounds
 			'+2015-00-01T00:00:00Z',
+			'+2015-01-00T01:00:00Z',
+			'+2015-01-00T00:01:00Z',
+			'+2015-01-00T00:00:01Z',
 			'+2015-13-01T00:00:00Z',
 			'+2015-01-32T00:00:00Z',
 			'+2015-01-01T24:00:00Z',


### PR DESCRIPTION
Same as #88, but for combinations that include non-zero hours, minutes or seconds.

This is not relevant in production because our validators don't accept anything but `…T00:00:00Z`. Still a bug that needs fixing.

I'm also untangling a few of the `if`s because of the [guard design pattern](https://en.wikipedia.org/wiki/Guard_(computer_science)). It is of no benefit to use `else` because all these `if`s throw an exception anyway.