### PR TITLE
Enable space before single line comment PHPCS rule

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -4,7 +4,6 @@
 	<rule ref="vendor/mediawiki/mediawiki-codesniffer/MediaWiki">
 		<exclude name="Generic.Arrays.DisallowLongArraySyntax" />
 		<exclude name="Generic.NamingConventions.UpperCaseConstantName" />
-		<exclude name="MediaWiki.WhiteSpace.SpaceBeforeSingleLineComment" />
 	</rule>
 
 	<rule ref="Generic.ControlStructures" />
@@ -34,6 +33,12 @@
 			<property name="spacing" value="1" />
 		</properties>
 	</rule>
+	<rule ref="Squiz.WhiteSpace.OperatorSpacing">
+		<properties>
+			<property name="ignoreNewlines" value="true" />
+		</properties>
+	</rule>
 
 	<arg name="extensions" value="php" />
+	<arg name="encoding" value="utf8" />
 </ruleset>

--- a/src/ValueParsers/IsoTimestampParser.php
+++ b/src/ValueParsers/IsoTimestampParser.php
@@ -108,13 +108,13 @@ class IsoTimestampParser extends StringValueParser {
 	 * 5 => minute, 6 => second and 7 => calendar model.
 	 */
 	private function splitTimeString( $value ) {
-		$pattern = '@^\s*'                                                //leading spaces
-			. "([-+\xE2\x88\x92]?)\\s*"                                   //sign
-			. '(\d{1,16})-(\d{2})-(\d{2})'                                //year, month and day
-			. '(?:T(\d{2}):?(\d{2})(?::?(\d{2}))?)?'                      //hour, minute and second
-			. 'Z?'                                                        //time zone
-			. '\s*\(?\s*' . CalendarModelParser::MODEL_PATTERN . '\s*\)?' //calendar model
-			. '\s*$@iu';                                                  //trailing spaces
+		$pattern = '@^\s*'                                                // leading spaces
+			. "([-+\xE2\x88\x92]?)\\s*"                                   // sign
+			. '(\d{1,16})-(\d{2})-(\d{2})'                                // year-month-day
+			. '(?:T(\d{2}):?(\d{2})(?::?(\d{2}))?)?'                      // hour:minute:second
+			. 'Z?'                                                        // time zone
+			. '\s*\(?\s*' . CalendarModelParser::MODEL_PATTERN . '\s*\)?' // calendar model
+			. '\s*$@iu';                                                  // trailing spaces
 
 		if ( !preg_match( $pattern, $value, $matches ) ) {
 			throw new ParseException( 'Malformed time' );

--- a/src/ValueParsers/YearMonthTimeParser.php
+++ b/src/ValueParsers/YearMonthTimeParser.php
@@ -58,7 +58,8 @@ class YearMonthTimeParser extends StringValueParser {
 	 * @return TimeValue
 	 */
 	protected function stringParse( $value ) {
-		//Matches Year and month separated by a separator, \p{L} matches letters outside the ASCII range
+		// Matches year and month separated by a separator.
+		// \p{L} matches letters outside the ASCII range.
 		if ( !preg_match( '/^(-?[\d\p{L}]+)\s*?[\/\-\s.,]\s*(-?[\d\p{L}]+)$/', trim( $value ), $matches ) ) {
 			throw new ParseException( 'Failed to parse year and month', $value, self::FORMAT_NAME );
 		}

--- a/tests/ValueParsers/YearMonthTimeParserTest.php
+++ b/tests/ValueParsers/YearMonthTimeParserTest.php
@@ -170,7 +170,7 @@ class YearMonthTimeParserTest extends StringValueParserTest {
 		$argLists = parent::invalidInputProvider();
 
 		$invalid = array(
-			//These are just wrong!
+			// These are just wrong
 			'June June June',
 			'June June',
 			'111 111 111',
@@ -190,11 +190,11 @@ class YearMonthTimeParserTest extends StringValueParserTest {
 			'00001 1999',
 			'000000001 100001999',
 
-			//Dont parse stuff with separators in the year
+			// Dont parse stuff with separators in the year
 			'june 200,000,000',
 			'june 200.000.000',
 
-			//Not within the scope of this parser
+			// Not within the scope of this parser
 			'1 June 20000',
 			'20000',
 			'-1998',

--- a/tests/ValueParsers/YearTimeParserTest.php
+++ b/tests/ValueParsers/YearTimeParserTest.php
@@ -133,15 +133,15 @@ class YearTimeParserTest extends StringValueParserTest {
 		$argLists = parent::invalidInputProvider();
 
 		$invalid = array(
-			//These are just wrong!
+			// These are just wrong
 			'June June June',
 			'111 111 111',
 			'Jann 2014',
 
-			//Not within the scope of this parser
+			// Not within the scope of this parser
 			'1 July 20000',
 
-			//We should not try to parse these, this just gets confusing
+			// We should not try to parse these, this just gets confusing
 			'-100BC',
 			'+100BC',
 			'-100 BC',


### PR DESCRIPTION
… and enable the OperatorSpacing rule. It turned out to be helpful in other code repositories. This code here is already fine.