### PR TITLE
Raised required PHP version from 5.3 to 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,21 @@
 language: php
 
+dist: trusty
+
 php:
-  - 5.3
-  - 5.4
   - 5.5
   - 5.6
-  - 7
+  - 7.0
   - 7.1
   - hhvm
 
 install: travis_retry composer install
 
-script: phpunit
+script: composer test
 
 after_success:
   - if [[ "`phpenv version-name`" != "7.1" ]]; then exit 0; fi
-  - phpunit --coverage-clover coverage.clover
+  - vendor/bin/phpunit --coverage-clover coverage.clover
   - wget https://scrutinizer-ci.com/ocular.phar
   - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ DataValues Time has been written by the Wikidata team, as [Wikimedia Germany]
 
 ## Release notes
 
+### 0.8.5 (dev)
+
+* Raised required PHP version from 5.3 to 5.5.
+
 ### 0.8.4 (2016-04-20)
 
 * Added `MonthNameProvider` interface.

--- a/composer.json
+++ b/composer.json
@@ -51,6 +51,7 @@
 		],
 		"test": [
 			"@validate --no-interaction",
+			"@phpcs",
 			"vendor/bin/phpunit"
 		]
 	}

--- a/composer.json
+++ b/composer.json
@@ -21,13 +21,14 @@
 		"irc": "irc://irc.freenode.net/wikidata"
 	},
 	"require": {
-		"php": ">=5.3.0",
+		"php": ">=5.5.9",
 		"data-values/data-values": "~1.0|~0.1",
 		"data-values/interfaces": "~0.2.0|~0.1.5",
 		"data-values/common": "~0.3.0|~0.2.0"
 	},
 	"require-dev": {
-		"mediawiki/mediawiki-codesniffer": "~0.5"
+		"mediawiki/mediawiki-codesniffer": ">=0.4 <0.8",
+		"phpunit/phpunit": "~4.8"
 	},
 	"autoload": {
 		"files" : [
@@ -47,6 +48,10 @@
 	"scripts": {
 		"phpcs": [
 			"vendor/bin/phpcs src/* tests/* --standard=phpcs.xml -sp"
+		],
+		"test": [
+			"@validate --no-interaction",
+			"vendor/bin/phpunit"
 		]
 	}
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -7,11 +7,16 @@
 	</rule>
 
 	<rule ref="Generic.ControlStructures" />
+
+	<rule ref="Generic.Files.InlineHTML" />
 	<rule ref="Generic.Files.LineLength">
 		<properties>
 			<property name="lineLimit" value="103" />
 		</properties>
 	</rule>
+	<rule ref="Generic.Files.OneClassPerFile" />
+	<rule ref="Generic.Files.OneInterfacePerFile" />
+	<rule ref="Generic.Files.OneTraitPerFile" />
 	<rule ref="Generic.PHP.CharacterBeforePHPOpeningTag" />
 
 	<rule ref="PSR1" />
@@ -22,6 +27,7 @@
 
 	<rule ref="PSR2.Files" />
 
+	<rule ref="Squiz.Arrays.ArrayBracketSpacing" />
 	<rule ref="Squiz.Classes.DuplicateProperty" />
 	<rule ref="Squiz.Classes.SelfMemberReference" />
 	<rule ref="Squiz.ControlStructures.ControlSignature" />
@@ -39,6 +45,8 @@
 		</properties>
 	</rule>
 
+	<file>.</file>
 	<arg name="extensions" value="php" />
 	<arg name="encoding" value="utf8" />
+	<exclude-pattern type="relative">^vendor/</exclude-pattern>
 </ruleset>


### PR DESCRIPTION
I also need to pin the PHPUnit and MediaWiki CodeSniffer versions, otherwise incompatible versions will be used.

[Bug: T165300](https://phabricator.wikimedia.org/T165300)