### PR TITLE
Remove "dist: trusty" from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: php
 
-dist: trusty
-
 php:
   - 5.5
   - 5.6


### PR DESCRIPTION
When this succeeds, it means the bug https://github.com/travis-ci/travis-ci/issues/7712 is resolved and we can remove the line `dist: trusty` from all our code repositories again.