### PR TITLE
Drop compatibility with DataValues Interfaces <0.2 and Common <0.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
 	"require": {
 		"php": ">=5.5.9",
 		"data-values/data-values": "~1.0|~0.1",
-		"data-values/interfaces": "~0.2.0|~0.1.5",
-		"data-values/common": "~0.4.0|~0.3.0|~0.2.0"
+		"data-values/interfaces": "~0.2.0",
+		"data-values/common": "~0.4.0|~0.3.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "~4.8",

--- a/tests/ValueFormatters/TimeFormatterTest.php
+++ b/tests/ValueFormatters/TimeFormatterTest.php
@@ -19,13 +19,6 @@ use ValueFormatters\TimeFormatter;
 class TimeFormatterTest extends ValueFormatterTestBase {
 
 	/**
-	 * @deprecated since DataValues Interfaces 0.2, just use getInstance.
-	 */
-	protected function getFormatterClass() {
-		throw new \LogicException( 'Should not be called, use getInstance' );
-	}
-
-	/**
 	 * @see ValueFormatterTestBase::getInstance
 	 *
 	 * @param FormatterOptions|null $options

--- a/tests/ValueParsers/CalendarModelParserTest.php
+++ b/tests/ValueParsers/CalendarModelParserTest.php
@@ -17,13 +17,6 @@ use ValueParsers\ParserOptions;
 class CalendarModelParserTest extends ValueParserTestBase {
 
 	/**
-	 * @deprecated since DataValues Common 0.3, just use getInstance.
-	 */
-	protected function getParserClass() {
-		throw new \LogicException( 'Should not be called, use getInstance' );
-	}
-
-	/**
 	 * @see ValueParserTestBase::getInstance
 	 *
 	 * @return CalendarModelParser

--- a/tests/ValueParsers/EraParserTest.php
+++ b/tests/ValueParsers/EraParserTest.php
@@ -19,13 +19,6 @@ use ValueParsers\EraParser;
 class EraParserTest extends StringValueParserTest {
 
 	/**
-	 * @deprecated since DataValues Common 0.3, just use getInstance.
-	 */
-	protected function getParserClass() {
-		throw new \LogicException( 'Should not be called, use getInstance' );
-	}
-
-	/**
 	 * @see ValueParserTestBase::getInstance
 	 *
 	 * @return EraParser

--- a/tests/ValueParsers/IsoTimestampParserTest.php
+++ b/tests/ValueParsers/IsoTimestampParserTest.php
@@ -18,13 +18,6 @@ use ValueParsers\ParserOptions;
 class IsoTimestampParserTest extends ValueParserTestBase {
 
 	/**
-	 * @deprecated since DataValues Common 0.3, just use getInstance.
-	 */
-	protected function getParserClass() {
-		throw new \LogicException( 'Should not be called, use getInstance' );
-	}
-
-	/**
 	 * @see ValueParserTestBase::getInstance
 	 *
 	 * @return IsoTimestampParser

--- a/tests/ValueParsers/PhpDateTimeParserTest.php
+++ b/tests/ValueParsers/PhpDateTimeParserTest.php
@@ -24,13 +24,6 @@ use ValueParsers\ValueParser;
 class PhpDateTimeParserTest extends StringValueParserTest {
 
 	/**
-	 * @deprecated since DataValues Common 0.3, just use getInstance.
-	 */
-	protected function getParserClass() {
-		throw new \LogicException( 'Should not be called, use getInstance' );
-	}
-
-	/**
 	 * @see ValueParserTestBase::getInstance
 	 *
 	 * @return PhpDateTimeParser

--- a/tests/ValueParsers/YearMonthDayTimeParserTest.php
+++ b/tests/ValueParsers/YearMonthDayTimeParserTest.php
@@ -21,13 +21,6 @@ use ValueParsers\YearMonthDayTimeParser;
 class YearMonthDayTimeParserTest extends StringValueParserTest {
 
 	/**
-	 * @deprecated since DataValues Common 0.3, just use getInstance.
-	 */
-	protected function getParserClass() {
-		throw new \LogicException( 'Should not be called, use getInstance' );
-	}
-
-	/**
 	 * @see ValueParserTestBase::getInstance
 	 *
 	 * @return YearMonthDayTimeParser

--- a/tests/ValueParsers/YearMonthTimeParserTest.php
+++ b/tests/ValueParsers/YearMonthTimeParserTest.php
@@ -20,13 +20,6 @@ use ValueParsers\YearMonthTimeParser;
 class YearMonthTimeParserTest extends StringValueParserTest {
 
 	/**
-	 * @deprecated since DataValues Common 0.3, just use getInstance.
-	 */
-	protected function getParserClass() {
-		throw new \LogicException( 'Should not be called, use getInstance' );
-	}
-
-	/**
 	 * @see ValueParserTestBase::getInstance
 	 *
 	 * @return YearMonthTimeParser

--- a/tests/ValueParsers/YearTimeParserTest.php
+++ b/tests/ValueParsers/YearTimeParserTest.php
@@ -22,13 +22,6 @@ use ValueParsers\YearTimeParser;
 class YearTimeParserTest extends StringValueParserTest {
 
 	/**
-	 * @deprecated since DataValues Common 0.3, just use getInstance.
-	 */
-	protected function getParserClass() {
-		throw new \LogicException( 'Should not be called, use getInstance' );
-	}
-
-	/**
 	 * @see ValueParserTestBase::getInstance
 	 *
 	 * @return YearTimeParser


### PR DESCRIPTION
This is not a breaking change and can be merged any time. But it can also wait. It must not be merged immediately. Keeping this a little longer doesn't hurt. I'm just uploading this patch so we don't forget.