### PR TITLE
Remove not needed "composer phpcs" command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,13 +46,10 @@
 		}
 	},
 	"scripts": {
-		"phpcs": [
-			"vendor/bin/phpcs src/* tests/* --standard=phpcs.xml -sp"
-		],
 		"test": [
 			"@validate --no-interaction",
-			"@phpcs",
-			"vendor/bin/phpunit"
+			"phpcs -p -s",
+			"phpunit"
 		]
 	}
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <ruleset name="DataValuesTime">
-	<rule ref="vendor/wikibase/wikibase-codesniffer/Wikibase">
+	<rule ref="./vendor/wikibase/wikibase-codesniffer/Wikibase">
 		<exclude name="Generic.Arrays.DisallowLongArraySyntax" />
 	</rule>
 


### PR DESCRIPTION
Similar to all "Remove non-standard Composer commands" patches I'm removing the awkward "phpcs" command here. I'm also simplifying the command a lot, which makes it even more obvious that this is not needed as a separate command. Before it made some sense to have a shortcut. Now it doesn't any more.

I just forgot to simplify this command in #130.