### PR TITLE
Remove duplicate is_string check from IsoTimestampParser

### DIFF
--- a/src/ValueParsers/IsoTimestampParser.php
+++ b/src/ValueParsers/IsoTimestampParser.php
@@ -4,7 +4,6 @@ namespace ValueParsers;
 
 use DataValues\IllegalValueException;
 use DataValues\TimeValue;
-use InvalidArgumentException;
 
 /**
  * ValueParser that parses various string representations of time values, in YMD ordered formats
@@ -73,15 +72,10 @@ class IsoTimestampParser extends StringValueParser {
 	/**
 	 * @param string $value
 	 *
-	 * @throws InvalidArgumentException
 	 * @throws ParseException
 	 * @return TimeValue
 	 */
 	protected function stringParse( $value ) {
-		if ( !is_string( $value ) ) {
-			throw new InvalidArgumentException( '$value must be a string' );
-		}
-
 		try {
 			$timeParts = $this->splitTimeString( $value );
 		} catch ( ParseException $ex ) {


### PR DESCRIPTION
This is already checked by the base class. The $value passed to stringParse is guaranteed to be a string (hence the name of the method).

Please merge https://github.com/DataValues/Number/pull/114 along with this, as it is the same patch in an other component.